### PR TITLE
Fixed "plot_results.py" adds too many zeros in the generated "heatmap.pdf"

### DIFF
--- a/plot_results.py
+++ b/plot_results.py
@@ -9,6 +9,9 @@ import matplotlib.pyplot as plt
 from scipy.stats.mstats import gmean
 from npbench.infrastructure import utilities as util
 
+def my_round(x, width):
+    float_format = "{:." + f"{width}" +  "f}"
+    return float_format.format(x)
 
 # geomean which ignores NA values
 def my_geomean(x):
@@ -31,9 +34,9 @@ def my_speedup_abbr(x):
     if x > 100:
         x = int(x)
     if x > 1000:
-        label = prefix + str(round(x / 1000, 1)) + "k"
+        label = prefix + str(my_round(x / 1000, 1)) + "k"
     else:
-        label = prefix + str(round(x, 1))
+        label = prefix + str(my_round(x, 1))
     return str(label)
 
 
@@ -45,7 +48,7 @@ def my_runtime_abbr(x):
     if x < 0.1:
         x = x * 1000
         suffix = " ms"
-    return str(round(x, 2)) + suffix
+    return str(my_round(x, 2)) + suffix
 
 
 def bootstrap_ci(data, statfunction=np.median, alpha=0.05, n_samples=300):


### PR DESCRIPTION
## Summary
Fixed `plot_results.py` will add too many zeros to the tail of some entry.

## Problem description
By the nature of floating points, rounding a floating point might still come with a very small bias.
And this bias would make "plot_results.py" generates result like the following.
![image](https://user-images.githubusercontent.com/24632731/229299540-c1b8569a-97b4-4164-a549-c9ac8082f6fd.png)

## Code changed
`npbench/plot_results.py`, Implemented another round function that only keeps a given number of decimals.

## Result
![image](https://user-images.githubusercontent.com/24632731/229299605-d2d8c6bc-a13e-4142-a359-8662dfc360aa.png)
