### PR TITLE
Zeros-init + well-conditioned Gram-Schmidt; add dace_canonicalize_{cpu,gpu} frameworks

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,11 @@ python -m pip install dace
 ```
 However, you may want to install the latest version from the [GitHub repository](https://github.com/spcl/dace).
 To run NPBench with DaCe, you have to select as framework (see details below)
-either `dace_cpu` or `dace_gpu`.
+either `dace_cpu` or `dace_gpu` (which build the SDFG and `auto_optimize` it), or
+`dace_canonicalize_cpu` / `dace_canonicalize_gpu` (which instead run DaCe's
+`canonicalize` pipeline, leaving `sdfg.openmp_array_reductions` on so whole-buffer
+WCR accumulators lower to OpenMP array-section reductions rather than per-element
+atomics).
 
 ### DPNP
 

--- a/framework_info/dace_canonicalize_cpu.json
+++ b/framework_info/dace_canonicalize_cpu.json
@@ -1,0 +1,10 @@
+{
+    "framework": {
+        "simple_name": "dace_canonicalize_cpu",
+        "full_name": "DaCe Canonicalize CPU",
+        "prefix": "dc",
+        "postfix": "dace",
+        "class": "DaceCanonicalizeFramework",
+        "arch": "cpu"
+    }
+}

--- a/framework_info/dace_canonicalize_gpu.json
+++ b/framework_info/dace_canonicalize_gpu.json
@@ -1,0 +1,10 @@
+{
+    "framework": {
+        "simple_name": "dace_canonicalize_gpu",
+        "full_name": "DaCe Canonicalize GPU",
+        "prefix": "dc",
+        "postfix": "dace",
+        "class": "DaceCanonicalizeFramework",
+        "arch": "gpu"
+    }
+}

--- a/npbench/benchmarks/cavity_flow/cavity_flow_cupy.py
+++ b/npbench/benchmarks/cavity_flow/cavity_flow_cupy.py
@@ -22,7 +22,7 @@ def build_up_b(b, rho, dt, u, v, dx, dy):
 
 
 def pressure_poisson(nit, p, dx, dy, b):
-    pn = np.empty_like(p)
+    pn = np.zeros_like(p)
     pn = p.copy()
 
     for q in range(nit):
@@ -39,8 +39,8 @@ def pressure_poisson(nit, p, dx, dy, b):
 
 
 def cavity_flow(nx, ny, nt, nit, u, v, dt, dx, dy, p, rho, nu):
-    un = np.empty_like(u)
-    vn = np.empty_like(v)
+    un = np.zeros_like(u)
+    vn = np.zeros_like(v)
     b = np.zeros((ny, nx))
 
     for n in range(nt):

--- a/npbench/benchmarks/cavity_flow/cavity_flow_dace.py
+++ b/npbench/benchmarks/cavity_flow/cavity_flow_dace.py
@@ -30,7 +30,7 @@ def build_up_b(b: dc.float64[ny, nx], rho: dc.float64, dt: dc.float64,
 @dc.program
 def pressure_poisson(p: dc.float64[ny, nx], dx: dc.float64, dy: dc.float64,
                      b: dc.float64[ny, nx]):
-    pn = np.empty_like(p)
+    pn = np.zeros_like(p)
     pn[:] = p.copy()
 
     for q in range(nit):
@@ -51,8 +51,8 @@ def cavity_flow(nt: dc.int64, nit: dc.int64, u: dc.float64[ny, nx],
                 v: dc.float64[ny, nx], dt: dc.float64, dx: dc.float64,
                 dy: dc.float64, p: dc.float64[ny, nx], rho: dc.float64,
                 nu: dc.float64):
-    un = np.empty_like(u)
-    vn = np.empty_like(v)
+    un = np.zeros_like(u)
+    vn = np.zeros_like(v)
     b = np.zeros((ny, nx))
 
     for n in range(nt):

--- a/npbench/benchmarks/cavity_flow/cavity_flow_dpnp.py
+++ b/npbench/benchmarks/cavity_flow/cavity_flow_dpnp.py
@@ -13,7 +13,7 @@ def build_up_b(b, rho, dt, u, v, dx, dy):
     )
 
 def pressure_poisson(nit, p, dx, dy, b):
-    pn = np.empty_like(p)
+    pn = np.zeros_like(p)
     for q in range(nit):
         pn[:] = p.copy()
         p[1:-1, 1:-1] = (
@@ -29,8 +29,8 @@ def pressure_poisson(nit, p, dx, dy, b):
         p[-1, :] = 0  # p = 0 at y = 2
 
 def cavity_flow(nx, ny, nt, nit, u, v, dt, dx, dy, p, rho, nu):
-    un = np.empty_like(u)
-    vn = np.empty_like(v)
+    un = np.zeros_like(u)
+    vn = np.zeros_like(v)
     b = np.zeros((ny, nx))
 
     for n in range(nt):

--- a/npbench/benchmarks/cavity_flow/cavity_flow_legate.py
+++ b/npbench/benchmarks/cavity_flow/cavity_flow_legate.py
@@ -22,7 +22,7 @@ def build_up_b(b, rho, dt, u, v, dx, dy):
 
 
 def pressure_poisson(nit, p, dx, dy, b):
-    pn = np.empty_like(p)
+    pn = np.zeros_like(p)
     pn = p.copy()
 
     for q in range(nit):
@@ -39,8 +39,8 @@ def pressure_poisson(nit, p, dx, dy, b):
 
 
 def cavity_flow(nx, ny, nt, nit, u, v, dt, dx, dy, p, rho, nu):
-    un = np.empty_like(u)
-    vn = np.empty_like(v)
+    un = np.zeros_like(u)
+    vn = np.zeros_like(v)
     b = np.zeros((ny, nx))
 
     for n in range(nt):

--- a/npbench/benchmarks/cavity_flow/cavity_flow_numba_n.py
+++ b/npbench/benchmarks/cavity_flow/cavity_flow_numba_n.py
@@ -16,7 +16,7 @@ def build_up_b(b, rho, dt, u, v, dx, dy):
 
 @nb.jit(nopython=True, parallel=False, fastmath=True)
 def pressure_poisson(nit, p, dx, dy, b):
-    pn = np.empty_like(p)
+    pn = np.zeros_like(p)
     pn = p.copy()
 
     for q in range(nit):
@@ -34,8 +34,8 @@ def pressure_poisson(nit, p, dx, dy, b):
 
 @nb.jit(nopython=True, parallel=False, fastmath=True)
 def cavity_flow(nx, ny, nt, nit, u, v, dt, dx, dy, p, rho, nu):
-    un = np.empty_like(u)
-    vn = np.empty_like(v)
+    un = np.zeros_like(u)
+    vn = np.zeros_like(v)
     b = np.zeros((ny, nx))
 
     for n in range(nt):

--- a/npbench/benchmarks/cavity_flow/cavity_flow_numba_np.py
+++ b/npbench/benchmarks/cavity_flow/cavity_flow_numba_np.py
@@ -16,7 +16,7 @@ def build_up_b(b, rho, dt, u, v, dx, dy):
 
 @nb.jit(nopython=True, parallel=True, fastmath=True)
 def pressure_poisson(nit, p, dx, dy, b):
-    pn = np.empty_like(p)
+    pn = np.zeros_like(p)
     pn = p.copy()
 
     for q in range(nit):
@@ -34,8 +34,8 @@ def pressure_poisson(nit, p, dx, dy, b):
 
 @nb.jit(nopython=True, parallel=True, fastmath=True)
 def nopython_mode(nx, ny, nt, nit, u, v, dt, dx, dy, p, rho, nu):
-    un = np.empty_like(u)
-    vn = np.empty_like(v)
+    un = np.zeros_like(u)
+    vn = np.zeros_like(v)
     b = np.zeros((ny, nx))
 
     for n in range(nt):

--- a/npbench/benchmarks/cavity_flow/cavity_flow_numpy.py
+++ b/npbench/benchmarks/cavity_flow/cavity_flow_numpy.py
@@ -22,7 +22,7 @@ def build_up_b(b, rho, dt, u, v, dx, dy):
 
 
 def pressure_poisson(nit, p, dx, dy, b):
-    pn = np.empty_like(p)
+    pn = np.zeros_like(p)
     pn = p.copy()
 
     for q in range(nit):
@@ -39,8 +39,8 @@ def pressure_poisson(nit, p, dx, dy, b):
 
 
 def cavity_flow(nx, ny, nt, nit, u, v, dt, dx, dy, p, rho, nu):
-    un = np.empty_like(u)
-    vn = np.empty_like(v)
+    un = np.zeros_like(u)
+    vn = np.zeros_like(v)
     b = np.zeros((ny, nx))
 
     for n in range(nt):

--- a/npbench/benchmarks/cavity_flow/cavity_flow_pythran.py
+++ b/npbench/benchmarks/cavity_flow/cavity_flow_pythran.py
@@ -26,7 +26,7 @@ def build_up_b(b, rho, dt, u, v, dx, dy):
 # pythran export pressure_poisson(int64, float64[:,:], float64, float64,
 #                                 float64[:,:])
 def pressure_poisson(nit, p, dx, dy, b):
-    pn = np.empty_like(p)
+    pn = np.zeros_like(p)
     pn = p.copy()
 
     for q in range(nit):
@@ -46,8 +46,8 @@ def pressure_poisson(nit, p, dx, dy, b):
 #                            float64[:,:], float64, float64, float64,
 #                            float64[:,:], float64, float64)
 def cavity_flow(nx, ny, nt, nit, u, v, dt, dx, dy, p, rho, nu):
-    un = np.empty_like(u)
-    vn = np.empty_like(v)
+    un = np.zeros_like(u)
+    vn = np.zeros_like(v)
     b = np.zeros((ny, nx))
 
     for n in range(nt):

--- a/npbench/benchmarks/channel_flow/channel_flow_cupy.py
+++ b/npbench/benchmarks/channel_flow/channel_flow_cupy.py
@@ -40,7 +40,7 @@ def build_up_b(rho, dt, dx, dy, u, v):
 
 
 def pressure_poisson_periodic(nit, p, dx, dy, b):
-    pn = np.empty_like(p)
+    pn = np.zeros_like(p)
 
     for q in range(nit):
         pn = p.copy()

--- a/npbench/benchmarks/channel_flow/channel_flow_dace.py
+++ b/npbench/benchmarks/channel_flow/channel_flow_dace.py
@@ -47,7 +47,7 @@ def build_up_b(rho: dc.float64, dt: dc.float64, dx: dc.float64, dy: dc.float64,
 @dc.program
 def pressure_poisson_periodic(p: dc.float64[ny, nx], dx: dc.float64,
                               dy: dc.float64, b: dc.float64[ny, nx]):
-    pn = np.empty_like(p)
+    pn = np.zeros_like(p)
 
     for q in range(nit):
         pn[:] = p.copy()

--- a/npbench/benchmarks/channel_flow/channel_flow_dpnp.py
+++ b/npbench/benchmarks/channel_flow/channel_flow_dpnp.py
@@ -30,7 +30,7 @@ def build_up_b(rho, dt, dx, dy, u, v):
 
 
 def pressure_poisson_periodic(nit, p, dx, dy, b):
-    pn = np.empty_like(p)
+    pn = np.zeros_like(p)
 
     for q in range(nit):
         pn = p.copy()

--- a/npbench/benchmarks/channel_flow/channel_flow_numba_n.py
+++ b/npbench/benchmarks/channel_flow/channel_flow_numba_n.py
@@ -43,7 +43,7 @@ def build_up_b(rho, dt, dx, dy, u, v):
 
 @nb.jit(nopython=True, parallel=False, fastmath=True)
 def pressure_poisson_periodic(nit, p, dx, dy, b):
-    pn = np.empty_like(p)
+    pn = np.zeros_like(p)
 
     for q in range(nit):
         pn = p.copy()

--- a/npbench/benchmarks/channel_flow/channel_flow_numba_np.py
+++ b/npbench/benchmarks/channel_flow/channel_flow_numba_np.py
@@ -43,7 +43,7 @@ def build_up_b(rho, dt, dx, dy, u, v):
 
 @nb.jit(nopython=True, parallel=True, fastmath=True)
 def pressure_poisson_periodic(nit, p, dx, dy, b):
-    pn = np.empty_like(p)
+    pn = np.zeros_like(p)
 
     for q in range(nit):
         pn = p.copy()

--- a/npbench/benchmarks/channel_flow/channel_flow_numpy.py
+++ b/npbench/benchmarks/channel_flow/channel_flow_numpy.py
@@ -40,7 +40,7 @@ def build_up_b(rho, dt, dx, dy, u, v):
 
 
 def pressure_poisson_periodic(nit, p, dx, dy, b):
-    pn = np.empty_like(p)
+    pn = np.zeros_like(p)
 
     for q in range(nit):
         pn = p.copy()

--- a/npbench/benchmarks/channel_flow/channel_flow_pythran.py
+++ b/npbench/benchmarks/channel_flow/channel_flow_pythran.py
@@ -44,7 +44,7 @@ def build_up_b(rho, dt, dx, dy, u, v):
 # pythran export pressure_poisson_periodic(int64, float64[:,:], float64,
 #                                          float64, float64[:,:])
 def pressure_poisson_periodic(nit, p, dx, dy, b):
-    pn = np.empty_like(p)
+    pn = np.zeros_like(p)
 
     for q in range(nit):
         pn = p.copy()

--- a/npbench/benchmarks/deep_learning/conv2d_bias/conv2d_cupy.py
+++ b/npbench/benchmarks/deep_learning/conv2d_bias/conv2d_cupy.py
@@ -8,7 +8,7 @@ def conv2d(input, weights):
     H_out = input.shape[1] - K + 1
     W_out = input.shape[2] - K + 1
     C_out = weights.shape[3]
-    output = np.empty((N, H_out, W_out, C_out), dtype=np.float32)
+    output = np.zeros((N, H_out, W_out, C_out), dtype=np.float32)
 
     # Loop structure adapted from https://github.com/SkalskiP/ILearnDeepLearning.py/blob/ba0b5ba589d4e656141995e8d1a06d44db6ce58d/01_mysteries_of_neural_networks/06_numpy_convolutional_neural_net/src/layers/convolutional.py#L88
     for i in range(H_out):

--- a/npbench/benchmarks/deep_learning/conv2d_bias/conv2d_dpnp.py
+++ b/npbench/benchmarks/deep_learning/conv2d_bias/conv2d_dpnp.py
@@ -7,7 +7,7 @@ def conv2d(input, weights):
     C_out = weights.shape[3]  # Output channels
     H_out = H - K + 1
     W_out = W - K + 1
-    output = np.empty((N, H_out, W_out, C_out), dtype=np.float32)
+    output = np.zeros((N, H_out, W_out, C_out), dtype=np.float32)
 
     # Perform convolution manually by iterating over the kernel dimensions
     for i in range(K):

--- a/npbench/benchmarks/deep_learning/conv2d_bias/conv2d_jax.py
+++ b/npbench/benchmarks/deep_learning/conv2d_bias/conv2d_jax.py
@@ -11,7 +11,7 @@ def conv2d(input, weights):
     H_out = input.shape[1] - K + 1
     W_out = input.shape[2] - K + 1
     C_out = weights.shape[3]
-    output = jnp.empty((N, H_out, W_out, C_out), dtype=jnp.float32)
+    output = jnp.zeros((N, H_out, W_out, C_out), dtype=jnp.float32)
 
     def row_update(output, i):
         def col_update(output, j):

--- a/npbench/benchmarks/deep_learning/conv2d_bias/conv2d_numba_n.py
+++ b/npbench/benchmarks/deep_learning/conv2d_bias/conv2d_numba_n.py
@@ -11,7 +11,7 @@ def conv2d(input, weights):
     W_out = input.shape[2] - K + 1
     C_in = input.shape[3]
     C_out = weights.shape[3]
-    output = np.empty((N, H_out, W_out, C_out), dtype=np.float32)
+    output = np.zeros((N, H_out, W_out, C_out), dtype=np.float32)
 
     # Loop structure adapted from https://github.com/SkalskiP/ILearnDeepLearning.py/blob/ba0b5ba589d4e656141995e8d1a06d44db6ce58d/01_mysteries_of_neural_networks/06_numpy_convolutional_neural_net/src/layers/convolutional.py#L88
     for i in range(H_out):

--- a/npbench/benchmarks/deep_learning/conv2d_bias/conv2d_numba_np.py
+++ b/npbench/benchmarks/deep_learning/conv2d_bias/conv2d_numba_np.py
@@ -11,7 +11,7 @@ def conv2d(input, weights):
     W_out = input.shape[2] - K + 1
     C_in = input.shape[3]
     C_out = weights.shape[3]
-    output = np.empty((N, H_out, W_out, C_out), dtype=np.float32)
+    output = np.zeros((N, H_out, W_out, C_out), dtype=np.float32)
 
     # Loop structure adapted from https://github.com/SkalskiP/ILearnDeepLearning.py/blob/ba0b5ba589d4e656141995e8d1a06d44db6ce58d/01_mysteries_of_neural_networks/06_numpy_convolutional_neural_net/src/layers/convolutional.py#L88
     for i in range(H_out):

--- a/npbench/benchmarks/deep_learning/conv2d_bias/conv2d_numba_npr.py
+++ b/npbench/benchmarks/deep_learning/conv2d_bias/conv2d_numba_npr.py
@@ -11,7 +11,7 @@ def conv2d(input, weights):
     W_out = input.shape[2] - K + 1
     C_in = input.shape[3]
     C_out = weights.shape[3]
-    output = np.empty((N, H_out, W_out, C_out), dtype=np.float32)
+    output = np.zeros((N, H_out, W_out, C_out), dtype=np.float32)
 
     # Loop structure adapted from https://github.com/SkalskiP/ILearnDeepLearning.py/blob/ba0b5ba589d4e656141995e8d1a06d44db6ce58d/01_mysteries_of_neural_networks/06_numpy_convolutional_neural_net/src/layers/convolutional.py#L88
     for i in nb.prange(H_out):

--- a/npbench/benchmarks/deep_learning/conv2d_bias/conv2d_numba_o.py
+++ b/npbench/benchmarks/deep_learning/conv2d_bias/conv2d_numba_o.py
@@ -10,7 +10,7 @@ def conv2d(input, weights):
     H_out = input.shape[1] - K + 1
     W_out = input.shape[2] - K + 1
     C_out = weights.shape[3]
-    output = np.empty((N, H_out, W_out, C_out), dtype=np.float32)
+    output = np.zeros((N, H_out, W_out, C_out), dtype=np.float32)
 
     # Loop structure adapted from https://github.com/SkalskiP/ILearnDeepLearning.py/blob/ba0b5ba589d4e656141995e8d1a06d44db6ce58d/01_mysteries_of_neural_networks/06_numpy_convolutional_neural_net/src/layers/convolutional.py#L88
     for i in range(H_out):

--- a/npbench/benchmarks/deep_learning/conv2d_bias/conv2d_numba_op.py
+++ b/npbench/benchmarks/deep_learning/conv2d_bias/conv2d_numba_op.py
@@ -10,7 +10,7 @@ def conv2d(input, weights):
     H_out = input.shape[1] - K + 1
     W_out = input.shape[2] - K + 1
     C_out = weights.shape[3]
-    output = np.empty((N, H_out, W_out, C_out), dtype=np.float32)
+    output = np.zeros((N, H_out, W_out, C_out), dtype=np.float32)
 
     # Loop structure adapted from https://github.com/SkalskiP/ILearnDeepLearning.py/blob/ba0b5ba589d4e656141995e8d1a06d44db6ce58d/01_mysteries_of_neural_networks/06_numpy_convolutional_neural_net/src/layers/convolutional.py#L88
     for i in range(H_out):

--- a/npbench/benchmarks/deep_learning/conv2d_bias/conv2d_numba_opr.py
+++ b/npbench/benchmarks/deep_learning/conv2d_bias/conv2d_numba_opr.py
@@ -10,7 +10,7 @@ def conv2d(input, weights):
     H_out = input.shape[1] - K + 1
     W_out = input.shape[2] - K + 1
     C_out = weights.shape[3]
-    output = np.empty((N, H_out, W_out, C_out), dtype=np.float32)
+    output = np.zeros((N, H_out, W_out, C_out), dtype=np.float32)
 
     # Loop structure adapted from https://github.com/SkalskiP/ILearnDeepLearning.py/blob/ba0b5ba589d4e656141995e8d1a06d44db6ce58d/01_mysteries_of_neural_networks/06_numpy_convolutional_neural_net/src/layers/convolutional.py#L88
     for i in nb.prange(H_out):

--- a/npbench/benchmarks/deep_learning/conv2d_bias/conv2d_numpy.py
+++ b/npbench/benchmarks/deep_learning/conv2d_bias/conv2d_numpy.py
@@ -8,7 +8,7 @@ def conv2d(input, weights):
     H_out = input.shape[1] - K + 1
     W_out = input.shape[2] - K + 1
     C_out = weights.shape[3]
-    output = np.empty((N, H_out, W_out, C_out), dtype=np.float32)
+    output = np.zeros((N, H_out, W_out, C_out), dtype=np.float32)
 
     # Loop structure adapted from https://github.com/SkalskiP/ILearnDeepLearning.py/blob/ba0b5ba589d4e656141995e8d1a06d44db6ce58d/01_mysteries_of_neural_networks/06_numpy_convolutional_neural_net/src/layers/convolutional.py#L88
     for i in range(H_out):

--- a/npbench/benchmarks/deep_learning/conv2d_bias/conv2d_pythran.py
+++ b/npbench/benchmarks/deep_learning/conv2d_bias/conv2d_pythran.py
@@ -9,7 +9,7 @@ def conv2d(input, weights):
     H_out = input.shape[1] - K + 1
     W_out = input.shape[2] - K + 1
     C_out = weights.shape[3]
-    output = np.empty((N, H_out, W_out, C_out), dtype=np.float32)
+    output = np.zeros((N, H_out, W_out, C_out), dtype=np.float32)
 
     # Loop structure adapted from https://github.com/SkalskiP/ILearnDeepLearning.py/blob/ba0b5ba589d4e656141995e8d1a06d44db6ce58d/01_mysteries_of_neural_networks/06_numpy_convolutional_neural_net/src/layers/convolutional.py#L88
     for i in range(H_out):

--- a/npbench/benchmarks/deep_learning/lenet/lenet_cupy.py
+++ b/npbench/benchmarks/deep_learning/lenet/lenet_cupy.py
@@ -12,7 +12,7 @@ def conv2d(input, weights):
     H_out = input.shape[1] - K + 1
     W_out = input.shape[2] - K + 1
     C_out = weights.shape[3]
-    output = np.empty((N, H_out, W_out, C_out), dtype=np.float32)
+    output = np.zeros((N, H_out, W_out, C_out), dtype=np.float32)
 
     # Loop structure adapted from https://github.com/SkalskiP/ILearnDeepLearning.py/blob/ba0b5ba589d4e656141995e8d1a06d44db6ce58d/01_mysteries_of_neural_networks/06_numpy_convolutional_neural_net/src/layers/convolutional.py#L88
     for i in range(H_out):
@@ -28,7 +28,7 @@ def conv2d(input, weights):
 
 # 2x2 maxpool operator, as used in LeNet-5
 def maxpool2d(x):
-    output = np.empty(
+    output = np.zeros(
         [x.shape[0], x.shape[1] // 2, x.shape[2] // 2, x.shape[3]],
         dtype=x.dtype)
     for i in range(x.shape[1] // 2):

--- a/npbench/benchmarks/deep_learning/lenet/lenet_jax.py
+++ b/npbench/benchmarks/deep_learning/lenet/lenet_jax.py
@@ -16,7 +16,7 @@ def conv2d(input, weights):
     H_out = input.shape[1] - K + 1
     W_out = input.shape[2] - K + 1
     C_out = weights.shape[3]
-    output = jnp.empty((N, H_out, W_out, C_out), dtype=jnp.float32)
+    output = jnp.zeros((N, H_out, W_out, C_out), dtype=jnp.float32)
 
     def row_update(output, i):
         def col_update(output, j):
@@ -47,7 +47,7 @@ def conv2d(input, weights):
 # 2x2 maxpool operator, as used in LeNet-5
 @jax.jit
 def maxpool2d(x):
-    output = jnp.empty(
+    output = jnp.zeros(
         [x.shape[0], x.shape[1] // 2, x.shape[2] // 2, x.shape[3]],
         dtype=x.dtype)
     

--- a/npbench/benchmarks/deep_learning/lenet/lenet_numba_n.py
+++ b/npbench/benchmarks/deep_learning/lenet/lenet_numba_n.py
@@ -16,7 +16,7 @@ def conv2d(input, weights):
     W_out = input.shape[2] - K + 1
     C_in = input.shape[3]
     C_out = weights.shape[3]
-    output = np.empty((N, H_out, W_out, C_out), dtype=np.float32)
+    output = np.zeros((N, H_out, W_out, C_out), dtype=np.float32)
 
     # Loop structure adapted from https://github.com/SkalskiP/ILearnDeepLearning.py/blob/ba0b5ba589d4e656141995e8d1a06d44db6ce58d/01_mysteries_of_neural_networks/06_numpy_convolutional_neural_net/src/layers/convolutional.py#L88
     for i in range(H_out):
@@ -45,7 +45,7 @@ def maxpool2d(x):
     # output = np.empty(
     #     [x.shape[0], x.shape[1] // 2, x.shape[2] // 2, x.shape[3]],
     #     dtype=x.dtype)
-    output = np.empty(
+    output = np.zeros(
         (x.shape[0], x.shape[1] // 2, x.shape[2] // 2, x.shape[3]),
         dtype=x.dtype)
     for i in range(x.shape[1] // 2):

--- a/npbench/benchmarks/deep_learning/lenet/lenet_numba_np.py
+++ b/npbench/benchmarks/deep_learning/lenet/lenet_numba_np.py
@@ -16,7 +16,7 @@ def conv2d(input, weights):
     W_out = input.shape[2] - K + 1
     C_in = input.shape[3]
     C_out = weights.shape[3]
-    output = np.empty((N, H_out, W_out, C_out), dtype=np.float32)
+    output = np.zeros((N, H_out, W_out, C_out), dtype=np.float32)
 
     # Loop structure adapted from https://github.com/SkalskiP/ILearnDeepLearning.py/blob/ba0b5ba589d4e656141995e8d1a06d44db6ce58d/01_mysteries_of_neural_networks/06_numpy_convolutional_neural_net/src/layers/convolutional.py#L88
     for i in range(H_out):
@@ -45,7 +45,7 @@ def maxpool2d(x):
     # output = np.empty(
     #     [x.shape[0], x.shape[1] // 2, x.shape[2] // 2, x.shape[3]],
     #     dtype=x.dtype)
-    output = np.empty(
+    output = np.zeros(
         (x.shape[0], x.shape[1] // 2, x.shape[2] // 2, x.shape[3]),
         dtype=x.dtype)
     for i in range(x.shape[1] // 2):

--- a/npbench/benchmarks/deep_learning/lenet/lenet_numba_npr.py
+++ b/npbench/benchmarks/deep_learning/lenet/lenet_numba_npr.py
@@ -16,7 +16,7 @@ def conv2d(input, weights):
     W_out = input.shape[2] - K + 1
     C_in = input.shape[3]
     C_out = weights.shape[3]
-    output = np.empty((N, H_out, W_out, C_out), dtype=np.float32)
+    output = np.zeros((N, H_out, W_out, C_out), dtype=np.float32)
 
     # Loop structure adapted from https://github.com/SkalskiP/ILearnDeepLearning.py/blob/ba0b5ba589d4e656141995e8d1a06d44db6ce58d/01_mysteries_of_neural_networks/06_numpy_convolutional_neural_net/src/layers/convolutional.py#L88
     for i in nb.prange(H_out):
@@ -45,7 +45,7 @@ def maxpool2d(x):
     # output = np.empty(
     #     [x.shape[0], x.shape[1] // 2, x.shape[2] // 2, x.shape[3]],
     #     dtype=x.dtype)
-    output = np.empty(
+    output = np.zeros(
         (x.shape[0], x.shape[1] // 2, x.shape[2] // 2, x.shape[3]),
         dtype=x.dtype)
     for i in nb.prange(x.shape[1] // 2):

--- a/npbench/benchmarks/deep_learning/lenet/lenet_numba_o.py
+++ b/npbench/benchmarks/deep_learning/lenet/lenet_numba_o.py
@@ -15,7 +15,7 @@ def conv2d(input, weights):
     H_out = input.shape[1] - K + 1
     W_out = input.shape[2] - K + 1
     C_out = weights.shape[3]
-    output = np.empty((N, H_out, W_out, C_out), dtype=np.float32)
+    output = np.zeros((N, H_out, W_out, C_out), dtype=np.float32)
 
     # Loop structure adapted from https://github.com/SkalskiP/ILearnDeepLearning.py/blob/ba0b5ba589d4e656141995e8d1a06d44db6ce58d/01_mysteries_of_neural_networks/06_numpy_convolutional_neural_net/src/layers/convolutional.py#L88
     for i in range(H_out):
@@ -32,7 +32,7 @@ def conv2d(input, weights):
 # 2x2 maxpool operator, as used in LeNet-5
 @nb.jit(nopython=False, forceobj=True, parallel=False, fastmath=True)
 def maxpool2d(x):
-    output = np.empty(
+    output = np.zeros(
         [x.shape[0], x.shape[1] // 2, x.shape[2] // 2, x.shape[3]],
         dtype=x.dtype)
     for i in range(x.shape[1] // 2):

--- a/npbench/benchmarks/deep_learning/lenet/lenet_numba_op.py
+++ b/npbench/benchmarks/deep_learning/lenet/lenet_numba_op.py
@@ -15,7 +15,7 @@ def conv2d(input, weights):
     H_out = input.shape[1] - K + 1
     W_out = input.shape[2] - K + 1
     C_out = weights.shape[3]
-    output = np.empty((N, H_out, W_out, C_out), dtype=np.float32)
+    output = np.zeros((N, H_out, W_out, C_out), dtype=np.float32)
 
     # Loop structure adapted from https://github.com/SkalskiP/ILearnDeepLearning.py/blob/ba0b5ba589d4e656141995e8d1a06d44db6ce58d/01_mysteries_of_neural_networks/06_numpy_convolutional_neural_net/src/layers/convolutional.py#L88
     for i in range(H_out):
@@ -32,7 +32,7 @@ def conv2d(input, weights):
 # 2x2 maxpool operator, as used in LeNet-5
 @nb.jit(nopython=False, forceobj=True, parallel=True, fastmath=True)
 def maxpool2d(x):
-    output = np.empty(
+    output = np.zeros(
         [x.shape[0], x.shape[1] // 2, x.shape[2] // 2, x.shape[3]],
         dtype=x.dtype)
     for i in range(x.shape[1] // 2):

--- a/npbench/benchmarks/deep_learning/lenet/lenet_numba_opr.py
+++ b/npbench/benchmarks/deep_learning/lenet/lenet_numba_opr.py
@@ -15,7 +15,7 @@ def conv2d(input, weights):
     H_out = input.shape[1] - K + 1
     W_out = input.shape[2] - K + 1
     C_out = weights.shape[3]
-    output = np.empty((N, H_out, W_out, C_out), dtype=np.float32)
+    output = np.zeros((N, H_out, W_out, C_out), dtype=np.float32)
 
     # Loop structure adapted from https://github.com/SkalskiP/ILearnDeepLearning.py/blob/ba0b5ba589d4e656141995e8d1a06d44db6ce58d/01_mysteries_of_neural_networks/06_numpy_convolutional_neural_net/src/layers/convolutional.py#L88
     for i in nb.prange(H_out):
@@ -32,7 +32,7 @@ def conv2d(input, weights):
 # 2x2 maxpool operator, as used in LeNet-5
 @nb.jit(nopython=False, forceobj=True, parallel=True, fastmath=True)
 def maxpool2d(x):
-    output = np.empty(
+    output = np.zeros(
         [x.shape[0], x.shape[1] // 2, x.shape[2] // 2, x.shape[3]],
         dtype=x.dtype)
     for i in nb.prange(x.shape[1] // 2):

--- a/npbench/benchmarks/deep_learning/lenet/lenet_numpy.py
+++ b/npbench/benchmarks/deep_learning/lenet/lenet_numpy.py
@@ -12,7 +12,7 @@ def conv2d(input, weights):
     H_out = input.shape[1] - K + 1
     W_out = input.shape[2] - K + 1
     C_out = weights.shape[3]
-    output = np.empty((N, H_out, W_out, C_out), dtype=np.float32)
+    output = np.zeros((N, H_out, W_out, C_out), dtype=np.float32)
 
     # Loop structure adapted from https://github.com/SkalskiP/ILearnDeepLearning.py/blob/ba0b5ba589d4e656141995e8d1a06d44db6ce58d/01_mysteries_of_neural_networks/06_numpy_convolutional_neural_net/src/layers/convolutional.py#L88
     for i in range(H_out):
@@ -28,7 +28,7 @@ def conv2d(input, weights):
 
 # 2x2 maxpool operator, as used in LeNet-5
 def maxpool2d(x):
-    output = np.empty(
+    output = np.zeros(
         [x.shape[0], x.shape[1] // 2, x.shape[2] // 2, x.shape[3]],
         dtype=x.dtype)
     for i in range(x.shape[1] // 2):

--- a/npbench/benchmarks/deep_learning/lenet/lenet_pythran.py
+++ b/npbench/benchmarks/deep_learning/lenet/lenet_pythran.py
@@ -13,7 +13,7 @@ def conv2d(input, weights):
     H_out = input.shape[1] - K + 1
     W_out = input.shape[2] - K + 1
     C_out = weights.shape[3]
-    output = np.empty((N, H_out, W_out, C_out), dtype=np.float32)
+    output = np.zeros((N, H_out, W_out, C_out), dtype=np.float32)
 
     # Loop structure adapted from https://github.com/SkalskiP/ILearnDeepLearning.py/blob/ba0b5ba589d4e656141995e8d1a06d44db6ce58d/01_mysteries_of_neural_networks/06_numpy_convolutional_neural_net/src/layers/convolutional.py#L88
     for i in range(H_out):
@@ -36,7 +36,7 @@ def conv2d(input, weights):
 # 2x2 maxpool operator, as used in LeNet-5
 # pythran export maxpool2d(float32[:,:,:,:])
 def maxpool2d(x):
-    output = np.empty(
+    output = np.zeros(
         [x.shape[0], x.shape[1] // 2, x.shape[2] // 2, x.shape[3]],
         dtype=x.dtype)
     for i in range(x.shape[1] // 2):

--- a/npbench/benchmarks/deep_learning/mlp/mlp_numba_n.py
+++ b/npbench/benchmarks/deep_learning/mlp/mlp_numba_n.py
@@ -12,7 +12,7 @@ def relu(x):
 def softmax(x):
     new_shape = (x.shape[0], 1)
     # tmp_max = np.max(x, axis=-1, keepdims=True)
-    tmp_max = np.empty(new_shape, dtype=x.dtype)
+    tmp_max = np.zeros(new_shape, dtype=x.dtype)
     for i in range(x.shape[1]):
         tmp_max[:, 0] = np.max(x[:, i])
     tmp_out = np.exp(x - tmp_max)

--- a/npbench/benchmarks/deep_learning/mlp/mlp_numba_np.py
+++ b/npbench/benchmarks/deep_learning/mlp/mlp_numba_np.py
@@ -12,7 +12,7 @@ def relu(x):
 def softmax(x):
     new_shape = (x.shape[0], 1)
     # tmp_max = np.max(x, axis=-1, keepdims=True)
-    tmp_max = np.empty(new_shape, dtype=x.dtype)
+    tmp_max = np.zeros(new_shape, dtype=x.dtype)
     for i in range(x.shape[1]):
         tmp_max[:, 0] = np.max(x[:, i])
     tmp_out = np.exp(x - tmp_max)

--- a/npbench/benchmarks/deep_learning/mlp/mlp_numba_npr.py
+++ b/npbench/benchmarks/deep_learning/mlp/mlp_numba_npr.py
@@ -12,7 +12,7 @@ def relu(x):
 def softmax(x):
     new_shape = (x.shape[0], 1)
     # tmp_max = np.max(x, axis=-1, keepdims=True)
-    tmp_max = np.empty(new_shape, dtype=x.dtype)
+    tmp_max = np.zeros(new_shape, dtype=x.dtype)
     for i in nb.prange(x.shape[1]):
         tmp_max[:, 0] = np.max(x[:, i])
     tmp_out = np.exp(x - tmp_max)

--- a/npbench/benchmarks/deep_learning/resnet/resnet_cupy.py
+++ b/npbench/benchmarks/deep_learning/resnet/resnet_cupy.py
@@ -12,7 +12,7 @@ def conv2d(input, weights):
     H_out = input.shape[1] - K + 1
     W_out = input.shape[2] - K + 1
     C_out = weights.shape[3]
-    output = np.empty((N, H_out, W_out, C_out), dtype=np.float32)
+    output = np.zeros((N, H_out, W_out, C_out), dtype=np.float32)
 
     # Loop structure adapted from https://github.com/SkalskiP/ILearnDeepLearning.py/blob/ba0b5ba589d4e656141995e8d1a06d44db6ce58d/01_mysteries_of_neural_networks/06_numpy_convolutional_neural_net/src/layers/convolutional.py#L88
     for i in range(H_out):

--- a/npbench/benchmarks/deep_learning/resnet/resnet_jax.py
+++ b/npbench/benchmarks/deep_learning/resnet/resnet_jax.py
@@ -15,7 +15,7 @@ def conv2d(input, weights):
     H_out = input.shape[1] - K + 1
     W_out = input.shape[2] - K + 1
     C_out = weights.shape[3]
-    output = jnp.empty((N, H_out, W_out, C_out), dtype=jnp.float32)
+    output = jnp.zeros((N, H_out, W_out, C_out), dtype=jnp.float32)
 
     def row_update(output, i):
         def col_update(output, j):

--- a/npbench/benchmarks/deep_learning/resnet/resnet_numba_n.py
+++ b/npbench/benchmarks/deep_learning/resnet/resnet_numba_n.py
@@ -16,7 +16,7 @@ def conv2d(input, weights):
     W_out = input.shape[2] - K + 1
     C_in = input.shape[3]
     C_out = weights.shape[3]
-    output = np.empty((N, H_out, W_out, C_out), dtype=np.float32)
+    output = np.zeros((N, H_out, W_out, C_out), dtype=np.float32)
 
     # Loop structure adapted from https://github.com/SkalskiP/ILearnDeepLearning.py/blob/ba0b5ba589d4e656141995e8d1a06d44db6ce58d/01_mysteries_of_neural_networks/06_numpy_convolutional_neural_net/src/layers/convolutional.py#L88
     for i in range(H_out):
@@ -43,10 +43,10 @@ def conv2d(input, weights):
 @nb.jit(nopython=True, parallel=False, fastmath=True)
 def batchnorm2d(x, eps=1e-5):
     # mean = np.mean(x, axis=0, keepdims=True)
-    mean = np.empty(x.shape, dtype=x.dtype)
+    mean = np.zeros(x.shape, dtype=x.dtype)
     mean[:] = np.sum(x, axis=0) / x.shape[0]
     # std = np.std(x, axis=0, keepdims=True)
-    std = np.empty(x.shape, dtype=x.dtype)
+    std = np.zeros(x.shape, dtype=x.dtype)
     std[:] = np.sqrt(np.sum((x - mean)**2, axis=0) / x.shape[0])
     return (x - mean) / np.sqrt(std + eps)
 

--- a/npbench/benchmarks/deep_learning/resnet/resnet_numba_np.py
+++ b/npbench/benchmarks/deep_learning/resnet/resnet_numba_np.py
@@ -16,7 +16,7 @@ def conv2d(input, weights):
     W_out = input.shape[2] - K + 1
     C_in = input.shape[3]
     C_out = weights.shape[3]
-    output = np.empty((N, H_out, W_out, C_out), dtype=np.float32)
+    output = np.zeros((N, H_out, W_out, C_out), dtype=np.float32)
 
     # Loop structure adapted from https://github.com/SkalskiP/ILearnDeepLearning.py/blob/ba0b5ba589d4e656141995e8d1a06d44db6ce58d/01_mysteries_of_neural_networks/06_numpy_convolutional_neural_net/src/layers/convolutional.py#L88
     for i in range(H_out):
@@ -43,10 +43,10 @@ def conv2d(input, weights):
 @nb.jit(nopython=True, parallel=True, fastmath=True)
 def batchnorm2d(x, eps=1e-5):
     # mean = np.mean(x, axis=0, keepdims=True)
-    mean = np.empty(x.shape, dtype=x.dtype)
+    mean = np.zeros(x.shape, dtype=x.dtype)
     mean[:] = np.sum(x, axis=0) / x.shape[0]
     # std = np.std(x, axis=0, keepdims=True)
-    std = np.empty(x.shape, dtype=x.dtype)
+    std = np.zeros(x.shape, dtype=x.dtype)
     std[:] = np.sqrt(np.sum((x - mean)**2, axis=0) / x.shape[0])
     return (x - mean) / np.sqrt(std + eps)
 

--- a/npbench/benchmarks/deep_learning/resnet/resnet_numba_npr.py
+++ b/npbench/benchmarks/deep_learning/resnet/resnet_numba_npr.py
@@ -16,7 +16,7 @@ def conv2d(input, weights):
     W_out = input.shape[2] - K + 1
     C_in = input.shape[3]
     C_out = weights.shape[3]
-    output = np.empty((N, H_out, W_out, C_out), dtype=np.float32)
+    output = np.zeros((N, H_out, W_out, C_out), dtype=np.float32)
 
     # Loop structure adapted from https://github.com/SkalskiP/ILearnDeepLearning.py/blob/ba0b5ba589d4e656141995e8d1a06d44db6ce58d/01_mysteries_of_neural_networks/06_numpy_convolutional_neural_net/src/layers/convolutional.py#L88
     for i in nb.prange(H_out):
@@ -43,10 +43,10 @@ def conv2d(input, weights):
 @nb.jit(nopython=True, parallel=True, fastmath=True)
 def batchnorm2d(x, eps=1e-5):
     # mean = np.mean(x, axis=0, keepdims=True)
-    mean = np.empty(x.shape, dtype=x.dtype)
+    mean = np.zeros(x.shape, dtype=x.dtype)
     mean[:] = np.sum(x, axis=0) / x.shape[0]
     # std = np.std(x, axis=0, keepdims=True)
-    std = np.empty(x.shape, dtype=x.dtype)
+    std = np.zeros(x.shape, dtype=x.dtype)
     std[:] = np.sqrt(np.sum((x - mean)**2, axis=0) / x.shape[0])
     return (x - mean) / np.sqrt(std + eps)
 

--- a/npbench/benchmarks/deep_learning/resnet/resnet_numba_o.py
+++ b/npbench/benchmarks/deep_learning/resnet/resnet_numba_o.py
@@ -15,7 +15,7 @@ def conv2d(input, weights):
     H_out = input.shape[1] - K + 1
     W_out = input.shape[2] - K + 1
     C_out = weights.shape[3]
-    output = np.empty((N, H_out, W_out, C_out), dtype=np.float32)
+    output = np.zeros((N, H_out, W_out, C_out), dtype=np.float32)
 
     # Loop structure adapted from https://github.com/SkalskiP/ILearnDeepLearning.py/blob/ba0b5ba589d4e656141995e8d1a06d44db6ce58d/01_mysteries_of_neural_networks/06_numpy_convolutional_neural_net/src/layers/convolutional.py#L88
     for i in range(H_out):

--- a/npbench/benchmarks/deep_learning/resnet/resnet_numba_op.py
+++ b/npbench/benchmarks/deep_learning/resnet/resnet_numba_op.py
@@ -15,7 +15,7 @@ def conv2d(input, weights):
     H_out = input.shape[1] - K + 1
     W_out = input.shape[2] - K + 1
     C_out = weights.shape[3]
-    output = np.empty((N, H_out, W_out, C_out), dtype=np.float32)
+    output = np.zeros((N, H_out, W_out, C_out), dtype=np.float32)
 
     # Loop structure adapted from https://github.com/SkalskiP/ILearnDeepLearning.py/blob/ba0b5ba589d4e656141995e8d1a06d44db6ce58d/01_mysteries_of_neural_networks/06_numpy_convolutional_neural_net/src/layers/convolutional.py#L88
     for i in range(H_out):

--- a/npbench/benchmarks/deep_learning/resnet/resnet_numba_opr.py
+++ b/npbench/benchmarks/deep_learning/resnet/resnet_numba_opr.py
@@ -15,7 +15,7 @@ def conv2d(input, weights):
     H_out = input.shape[1] - K + 1
     W_out = input.shape[2] - K + 1
     C_out = weights.shape[3]
-    output = np.empty((N, H_out, W_out, C_out), dtype=np.float32)
+    output = np.zeros((N, H_out, W_out, C_out), dtype=np.float32)
 
     # Loop structure adapted from https://github.com/SkalskiP/ILearnDeepLearning.py/blob/ba0b5ba589d4e656141995e8d1a06d44db6ce58d/01_mysteries_of_neural_networks/06_numpy_convolutional_neural_net/src/layers/convolutional.py#L88
     for i in nb.prange(H_out):

--- a/npbench/benchmarks/deep_learning/resnet/resnet_numpy.py
+++ b/npbench/benchmarks/deep_learning/resnet/resnet_numpy.py
@@ -12,7 +12,7 @@ def conv2d(input, weights):
     H_out = input.shape[1] - K + 1
     W_out = input.shape[2] - K + 1
     C_out = weights.shape[3]
-    output = np.empty((N, H_out, W_out, C_out), dtype=np.float32)
+    output = np.zeros((N, H_out, W_out, C_out), dtype=np.float32)
 
     # Loop structure adapted from https://github.com/SkalskiP/ILearnDeepLearning.py/blob/ba0b5ba589d4e656141995e8d1a06d44db6ce58d/01_mysteries_of_neural_networks/06_numpy_convolutional_neural_net/src/layers/convolutional.py#L88
     for i in range(H_out):

--- a/npbench/benchmarks/deep_learning/resnet/resnet_pythran.py
+++ b/npbench/benchmarks/deep_learning/resnet/resnet_pythran.py
@@ -14,7 +14,7 @@ def conv2d(input, weights):
     H_out = input.shape[1] - K + 1
     W_out = input.shape[2] - K + 1
     C_out = weights.shape[3]
-    output = np.empty((N, H_out, W_out, C_out), dtype=np.float32)
+    output = np.zeros((N, H_out, W_out, C_out), dtype=np.float32)
 
     # Loop structure adapted from https://github.com/SkalskiP/ILearnDeepLearning.py/blob/ba0b5ba589d4e656141995e8d1a06d44db6ce58d/01_mysteries_of_neural_networks/06_numpy_convolutional_neural_net/src/layers/convolutional.py#L88
     for i in range(H_out):

--- a/npbench/benchmarks/deep_learning/softmax/softmax_numba_n.py
+++ b/npbench/benchmarks/deep_learning/softmax/softmax_numba_n.py
@@ -7,7 +7,7 @@ import numba as nb
 def softmax(x):
     new_shape = (x.shape[0], x.shape[1], x.shape[2], 1)
     # tmp_max = np.max(x, axis=-1, keepdims=True)
-    tmp_max = np.empty(new_shape, dtype=x.dtype)
+    tmp_max = np.zeros(new_shape, dtype=x.dtype)
     for i in range(x.shape[3]):
         tmp_max[:, :, :, 0] = np.max(x[:, :, :, i])
     tmp_out = np.exp(x - tmp_max)

--- a/npbench/benchmarks/deep_learning/softmax/softmax_numba_np.py
+++ b/npbench/benchmarks/deep_learning/softmax/softmax_numba_np.py
@@ -7,7 +7,7 @@ import numba as nb
 def softmax(x):
     new_shape = (x.shape[0], x.shape[1], x.shape[2], 1)
     # tmp_max = np.max(x, axis=-1, keepdims=True)
-    tmp_max = np.empty(new_shape, dtype=x.dtype)
+    tmp_max = np.zeros(new_shape, dtype=x.dtype)
     for i in range(x.shape[3]):
         tmp_max[:, :, :, 0] = np.max(x[:, :, :, i])
     tmp_out = np.exp(x - tmp_max)

--- a/npbench/benchmarks/deep_learning/softmax/softmax_numba_npr.py
+++ b/npbench/benchmarks/deep_learning/softmax/softmax_numba_npr.py
@@ -7,7 +7,7 @@ import numba as nb
 def softmax(x):
     new_shape = (x.shape[0], x.shape[1], x.shape[2], 1)
     # tmp_max = np.max(x, axis=-1, keepdims=True)
-    tmp_max = np.empty(new_shape, dtype=x.dtype)
+    tmp_max = np.zeros(new_shape, dtype=x.dtype)
     for i in nb.prange(x.shape[3]):
         tmp_max[:, :, :, 0] = np.max(x[:, :, :, i])
     tmp_out = np.exp(x - tmp_max)

--- a/npbench/benchmarks/mandelbrot1/mandelbrot1_legate.py
+++ b/npbench/benchmarks/mandelbrot1/mandelbrot1_legate.py
@@ -8,7 +8,7 @@ import legate.numpy as np
 
 
 def linspace(start, stop, num, dtype):
-    X = np.empty((num, ), dtype=dtype)
+    X = np.zeros((num, ), dtype=dtype)
     dist = (stop - start) / (num - 1)
     for i in range(num):
         X[i] = start + i * dist

--- a/npbench/benchmarks/mandelbrot1/mandelbrot1_numba_n.py
+++ b/npbench/benchmarks/mandelbrot1/mandelbrot1_numba_n.py
@@ -10,7 +10,7 @@ import numba as nb
 
 @nb.jit(nopython=True, parallel=False, fastmath=True)
 def linspace(start, stop, num, dtype):
-    X = np.empty((num, ), dtype=dtype)
+    X = np.zeros((num, ), dtype=dtype)
     dist = (stop - start) / (num - 1)
     for i in range(num):
         X[i] = start + i * dist

--- a/npbench/benchmarks/mandelbrot1/mandelbrot1_numba_np.py
+++ b/npbench/benchmarks/mandelbrot1/mandelbrot1_numba_np.py
@@ -10,7 +10,7 @@ import numba as nb
 
 @nb.jit(nopython=True, parallel=True, fastmath=True)
 def linspace(start, stop, num, dtype):
-    X = np.empty((num, ), dtype=dtype)
+    X = np.zeros((num, ), dtype=dtype)
     dist = (stop - start) / (num - 1)
     for i in range(num):
         X[i] = start + i * dist

--- a/npbench/benchmarks/mandelbrot1/mandelbrot1_numba_npr.py
+++ b/npbench/benchmarks/mandelbrot1/mandelbrot1_numba_npr.py
@@ -10,7 +10,7 @@ import numba as nb
 
 @nb.jit(nopython=True, parallel=True, fastmath=True)
 def linspace(start, stop, num, dtype):
-    X = np.empty((num, ), dtype=dtype)
+    X = np.zeros((num, ), dtype=dtype)
     dist = (stop - start) / (num - 1)
     for i in nb.prange(num):
         X[i] = start + i * dist

--- a/npbench/benchmarks/mandelbrot2/mandelbrot2_legate.py
+++ b/npbench/benchmarks/mandelbrot2/mandelbrot2_legate.py
@@ -8,7 +8,7 @@ import legate.numpy as np
 
 
 def linspace(start, stop, num, dtype):
-    X = np.empty((num, ), dtype=dtype)
+    X = np.zeros((num, ), dtype=dtype)
     dist = (stop - start) / (num - 1)
     for i in range(num):
         X[i] = start + i * dist

--- a/npbench/benchmarks/mandelbrot2/mandelbrot2_numba_n.py
+++ b/npbench/benchmarks/mandelbrot2/mandelbrot2_numba_n.py
@@ -10,8 +10,8 @@ import numba as nb
 
 @nb.jit(nopython=True, parallel=False, fastmath=True)
 def mgrid(xn, yn):
-    Xi = np.empty((xn, yn), dtype=np.int64)
-    Yi = np.empty((xn, yn), dtype=np.int64)
+    Xi = np.zeros((xn, yn), dtype=np.int64)
+    Yi = np.zeros((xn, yn), dtype=np.int64)
     for i in range(xn):
         Xi[i, :] = i
     for j in range(yn):
@@ -21,7 +21,7 @@ def mgrid(xn, yn):
 
 @nb.jit(nopython=True, parallel=False, fastmath=True)
 def linspace(start, stop, num, dtype):
-    X = np.empty((num, ), dtype=dtype)
+    X = np.zeros((num, ), dtype=dtype)
     dist = (stop - start) / (num - 1)
     for i in range(num):
         X[i] = start + i * dist

--- a/npbench/benchmarks/mandelbrot2/mandelbrot2_pythran.py
+++ b/npbench/benchmarks/mandelbrot2/mandelbrot2_pythran.py
@@ -8,8 +8,8 @@ import numpy as np
 
 
 def mgrid(xn, yn):
-    Xi = np.empty((xn, yn), dtype=np.int64)
-    Yi = np.empty((xn, yn), dtype=np.int64)
+    Xi = np.zeros((xn, yn), dtype=np.int64)
+    Yi = np.zeros((xn, yn), dtype=np.int64)
     for i in range(xn):
         Xi[i, :] = i
     for j in range(yn):

--- a/npbench/benchmarks/nbody/nbody_jax.py
+++ b/npbench/benchmarks/nbody/nbody_jax.py
@@ -92,8 +92,8 @@ def nbody(mass, pos, vel, N, Nt, dt, G, softening):
     acc = getAcc(pos, mass, G, softening)
 
     # calculate initial energy of system
-    KE = jnp.empty(Nt + 1, dtype=jnp.float64)
-    PE = jnp.empty(Nt + 1, dtype=jnp.float64)
+    KE = jnp.zeros(Nt + 1, dtype=jnp.float64)
+    PE = jnp.zeros(Nt + 1, dtype=jnp.float64)
     ke, pe = getEnergy(pos, vel, mass, G)
     KE = KE.at[0].set(ke)
     PE = PE.at[0].set(pe)

--- a/npbench/benchmarks/nbody/nbody_numba_n.py
+++ b/npbench/benchmarks/nbody/nbody_numba_n.py
@@ -106,8 +106,8 @@ def nbody(mass, pos, vel, N, Nt, dt, G, softening):
     # calculate initial energy of system
     # KE = np.ndarray(Nt+1, dtype=np.float64)
     # PE = np.ndarray(Nt+1, dtype=np.float64)
-    KE = np.empty(Nt + 1, dtype=np.float64)
-    PE = np.empty(Nt + 1, dtype=np.float64)
+    KE = np.zeros(Nt + 1, dtype=np.float64)
+    PE = np.zeros(Nt + 1, dtype=np.float64)
     KE[0], PE[0] = getEnergy(pos, vel, mass, G)
 
     t = 0.0

--- a/npbench/benchmarks/nbody/nbody_pythran.py
+++ b/npbench/benchmarks/nbody/nbody_pythran.py
@@ -95,8 +95,8 @@ def nbody(mass, pos, vel, N, Nt, dt, G, softening):
     # calculate initial energy of system
     # KE = np.ndarray(Nt+1, dtype=np.float64)
     # PE = np.ndarray(Nt+1, dtype=np.float64)
-    KE = np.empty(Nt + 1, dtype=np.float64)
-    PE = np.empty(Nt + 1, dtype=np.float64)
+    KE = np.zeros(Nt + 1, dtype=np.float64)
+    PE = np.zeros(Nt + 1, dtype=np.float64)
     KE[0], PE[0] = getEnergy(pos, vel, mass, G)
 
     t = 0.0

--- a/npbench/benchmarks/polybench/adi/adi_cupy.py
+++ b/npbench/benchmarks/polybench/adi/adi_cupy.py
@@ -5,9 +5,9 @@ import cupy as np
 
 def kernel(TSTEPS, N, u):
 
-    v = np.empty(u.shape, dtype=u.dtype)
-    p = np.empty(u.shape, dtype=u.dtype)
-    q = np.empty(u.shape, dtype=u.dtype)
+    v = np.zeros(u.shape, dtype=u.dtype)
+    p = np.zeros(u.shape, dtype=u.dtype)
+    q = np.zeros(u.shape, dtype=u.dtype)
 
     DX = 1.0 / N
     DY = 1.0 / N

--- a/npbench/benchmarks/polybench/adi/adi_dace.py
+++ b/npbench/benchmarks/polybench/adi/adi_dace.py
@@ -9,9 +9,9 @@ N = dc.symbol('N', dtype=dc.int64)
 @dc.program
 def kernel(TSTEPS: dc.int64, u: dc.float64[N, N]):
 
-    v = np.empty(u.shape, dtype=u.dtype)
-    p = np.empty(u.shape, dtype=u.dtype)
-    q = np.empty(u.shape, dtype=u.dtype)
+    v = np.zeros(u.shape, dtype=u.dtype)
+    p = np.zeros(u.shape, dtype=u.dtype)
+    q = np.zeros(u.shape, dtype=u.dtype)
 
     DX = 1.0 / np.float64(N)
     DY = 1.0 / np.float64(N)

--- a/npbench/benchmarks/polybench/adi/adi_dask.py
+++ b/npbench/benchmarks/polybench/adi/adi_dask.py
@@ -7,9 +7,9 @@ def kernel(TSTEPS, N, np_u):
 
     u = np.from_array(np_u, chunks='auto')
 
-    v = np.empty(u.shape, dtype=u.dtype)
-    p = np.empty(u.shape, dtype=u.dtype)
-    q = np.empty(u.shape, dtype=u.dtype)
+    v = np.zeros(u.shape, dtype=u.dtype)
+    p = np.zeros(u.shape, dtype=u.dtype)
+    q = np.zeros(u.shape, dtype=u.dtype)
 
     DX = 1.0 / N
     DY = 1.0 / N

--- a/npbench/benchmarks/polybench/adi/adi_dpnp.py
+++ b/npbench/benchmarks/polybench/adi/adi_dpnp.py
@@ -1,9 +1,9 @@
 import dpnp as np
 
 def kernel(TSTEPS, N, u):
-    v = np.empty(u.shape, dtype=u.dtype)
-    p = np.empty(u.shape, dtype=u.dtype)
-    q = np.empty(u.shape, dtype=u.dtype)
+    v = np.zeros(u.shape, dtype=u.dtype)
+    p = np.zeros(u.shape, dtype=u.dtype)
+    q = np.zeros(u.shape, dtype=u.dtype)
 
     DX = 1.0 / N
     DY = 1.0 / N

--- a/npbench/benchmarks/polybench/adi/adi_legate.py
+++ b/npbench/benchmarks/polybench/adi/adi_legate.py
@@ -5,9 +5,9 @@ import legate.numpy as np
 
 def kernel(TSTEPS, N, u):
 
-    v = np.empty(u.shape, dtype=u.dtype)
-    p = np.empty(u.shape, dtype=u.dtype)
-    q = np.empty(u.shape, dtype=u.dtype)
+    v = np.zeros(u.shape, dtype=u.dtype)
+    p = np.zeros(u.shape, dtype=u.dtype)
+    q = np.zeros(u.shape, dtype=u.dtype)
 
     DX = 1.0 / N
     DY = 1.0 / N

--- a/npbench/benchmarks/polybench/adi/adi_numba_n.py
+++ b/npbench/benchmarks/polybench/adi/adi_numba_n.py
@@ -7,9 +7,9 @@ import numba as nb
 @nb.jit(nopython=True, parallel=False, fastmath=True)
 def kernel(TSTEPS, N, u):
 
-    v = np.empty(u.shape, dtype=u.dtype)
-    p = np.empty(u.shape, dtype=u.dtype)
-    q = np.empty(u.shape, dtype=u.dtype)
+    v = np.zeros(u.shape, dtype=u.dtype)
+    p = np.zeros(u.shape, dtype=u.dtype)
+    q = np.zeros(u.shape, dtype=u.dtype)
 
     DX = 1.0 / N
     DY = 1.0 / N

--- a/npbench/benchmarks/polybench/adi/adi_numba_np.py
+++ b/npbench/benchmarks/polybench/adi/adi_numba_np.py
@@ -7,9 +7,9 @@ import numba as nb
 @nb.jit(nopython=True, parallel=True, fastmath=True)
 def kernel(TSTEPS, N, u):
 
-    v = np.empty(u.shape, dtype=u.dtype)
-    p = np.empty(u.shape, dtype=u.dtype)
-    q = np.empty(u.shape, dtype=u.dtype)
+    v = np.zeros(u.shape, dtype=u.dtype)
+    p = np.zeros(u.shape, dtype=u.dtype)
+    q = np.zeros(u.shape, dtype=u.dtype)
 
     DX = 1.0 / N
     DY = 1.0 / N

--- a/npbench/benchmarks/polybench/adi/adi_numpy.py
+++ b/npbench/benchmarks/polybench/adi/adi_numpy.py
@@ -5,9 +5,9 @@ import numpy as np
 
 def kernel(TSTEPS, N, u):
 
-    v = np.empty(u.shape, dtype=u.dtype)
-    p = np.empty(u.shape, dtype=u.dtype)
-    q = np.empty(u.shape, dtype=u.dtype)
+    v = np.zeros(u.shape, dtype=u.dtype)
+    p = np.zeros(u.shape, dtype=u.dtype)
+    q = np.zeros(u.shape, dtype=u.dtype)
 
     DX = 1.0 / N
     DY = 1.0 / N

--- a/npbench/benchmarks/polybench/adi/adi_pythran.py
+++ b/npbench/benchmarks/polybench/adi/adi_pythran.py
@@ -6,9 +6,9 @@ import numpy as np
 # pythran export kernel(int, int, float64[:,:])
 def kernel(TSTEPS, N, u):
 
-    v = np.empty(u.shape, dtype=u.dtype)
-    p = np.empty(u.shape, dtype=u.dtype)
-    q = np.empty(u.shape, dtype=u.dtype)
+    v = np.zeros(u.shape, dtype=u.dtype)
+    p = np.zeros(u.shape, dtype=u.dtype)
+    q = np.zeros(u.shape, dtype=u.dtype)
 
     DX = 1.0 / N
     DY = 1.0 / N

--- a/npbench/benchmarks/polybench/atax/atax_legate.py
+++ b/npbench/benchmarks/polybench/atax/atax_legate.py
@@ -10,10 +10,10 @@ def kernel(A, x):
 def init_data(M, N, datatype):
 
     fn = datatype(N)
-    A = np.empty((M, N), dtype=datatype)
-    x = np.empty((N, ), dtype=datatype)
-    y = np.empty((N, ), dtype=datatype)
-    tmp = np.empty((M, ), dtype=datatype)
+    A = np.zeros((M, N), dtype=datatype)
+    x = np.zeros((N, ), dtype=datatype)
+    y = np.zeros((N, ), dtype=datatype)
+    tmp = np.zeros((M, ), dtype=datatype)
     # for i in range(N):
     #     x[i] = 1 + (i / fn)
     # for i in range(M):

--- a/npbench/benchmarks/polybench/bicg/bicg_legate.py
+++ b/npbench/benchmarks/polybench/bicg/bicg_legate.py
@@ -9,11 +9,11 @@ def kernel(A, p, r):
 
 def init_data(M, N, datatype):
 
-    A = np.empty((N, M), dtype=datatype)
-    s = np.empty((M, ), dtype=datatype)
-    q = np.empty((N, ), dtype=datatype)
-    p = np.empty((M, ), dtype=datatype)
-    r = np.empty((N, ), dtype=datatype)
+    A = np.zeros((N, M), dtype=datatype)
+    s = np.zeros((M, ), dtype=datatype)
+    q = np.zeros((N, ), dtype=datatype)
+    p = np.zeros((M, ), dtype=datatype)
+    r = np.zeros((N, ), dtype=datatype)
     # for i in range(M):
     #     p[i] = (i % M) / M
     # for i in range(N):

--- a/npbench/benchmarks/polybench/cholesky/cholesky.py
+++ b/npbench/benchmarks/polybench/cholesky/cholesky.py
@@ -4,7 +4,7 @@ import numpy as np
 
 
 def initialize(N, datatype=np.float64):
-    A = np.empty((N, N), dtype=datatype)
+    A = np.zeros((N, N), dtype=datatype)
     for i in range(N):
         A[i, :i + 1] = np.fromfunction(lambda j: (-j % N) / N + 1, (i + 1, ),
                                        dtype=datatype)

--- a/npbench/benchmarks/polybench/cholesky/cholesky_legate.py
+++ b/npbench/benchmarks/polybench/cholesky/cholesky_legate.py
@@ -19,7 +19,7 @@ def kernel2(A):
 
 def init_data(N, datatype):
 
-    A = np.empty((N, N), dtype=datatype)
+    A = np.zeros((N, N), dtype=datatype)
     # for i in range(N):
     #     for j in range(i + 1):
     #         A[i, j] = (-j % N) / N + 1

--- a/npbench/benchmarks/polybench/cholesky2/cholesky2.py
+++ b/npbench/benchmarks/polybench/cholesky2/cholesky2.py
@@ -4,7 +4,7 @@ import numpy as np
 
 
 def initialize(N, datatype=np.float64):
-    A = np.empty((N, N), dtype=datatype)
+    A = np.zeros((N, N), dtype=datatype)
     for i in range(N):
         A[i, :i + 1] = np.fromfunction(lambda j: (-j % N) / N + 1, (i + 1, ),
                                        dtype=datatype)

--- a/npbench/benchmarks/polybench/cholesky2/cholesky2_legate.py
+++ b/npbench/benchmarks/polybench/cholesky2/cholesky2_legate.py
@@ -19,7 +19,7 @@ def kernel2(A):
 
 def init_data(N, datatype):
 
-    A = np.empty((N, N), dtype=datatype)
+    A = np.zeros((N, N), dtype=datatype)
     # for i in range(N):
     #     for j in range(i + 1):
     #         A[i, j] = (-j % N) / N + 1

--- a/npbench/benchmarks/polybench/correlation/correlation_legate.py
+++ b/npbench/benchmarks/polybench/correlation/correlation_legate.py
@@ -29,7 +29,7 @@ def kernel(M, float_n, data):
 def init_data(M, N, datatype):
 
     float_n = datatype(N)
-    data = np.empty((N, M), dtype=datatype)
+    data = np.zeros((N, M), dtype=datatype)
     # for i in range(N):
     #     for j in range(M):
     #         data[i, j] = (i * j) / M + i

--- a/npbench/benchmarks/polybench/covariance/covariance_legate.py
+++ b/npbench/benchmarks/polybench/covariance/covariance_legate.py
@@ -20,7 +20,7 @@ def kernel(M, float_n, data):
 def init_data(M, N, datatype):
 
     float_n = datatype(N)
-    data = np.empty((N, M), dtype=datatype)
+    data = np.zeros((N, M), dtype=datatype)
     # for i in range(N):
     #     for j in range(M):
     #         data[i, j] = (i * j) / M + i

--- a/npbench/benchmarks/polybench/deriche/deriche_cupy.py
+++ b/npbench/benchmarks/polybench/deriche/deriche_cupy.py
@@ -13,14 +13,14 @@ def kernel(alpha, imgIn):
     b2 = -np.exp(-2.0 * alpha)
     c1 = c2 = 1
 
-    y1 = np.empty_like(imgIn)
+    y1 = np.zeros_like(imgIn)
     y1[:, 0] = a1 * imgIn[:, 0]
     y1[:, 1] = a1 * imgIn[:, 1] + a2 * imgIn[:, 0] + b1 * y1[:, 0]
     for j in range(2, imgIn.shape[1]):
         y1[:, j] = (a1 * imgIn[:, j] + a2 * imgIn[:, j - 1] +
                     b1 * y1[:, j - 1] + b2 * y1[:, j - 2])
 
-    y2 = np.empty_like(imgIn)
+    y2 = np.zeros_like(imgIn)
     y2[:, -1] = 0.0
     y2[:, -2] = a3 * imgIn[:, -1]
     for j in range(imgIn.shape[1] - 3, -1, -1):

--- a/npbench/benchmarks/polybench/deriche/deriche_dace.py
+++ b/npbench/benchmarks/polybench/deriche/deriche_dace.py
@@ -22,14 +22,14 @@ def kernel(alpha: dc.float64, imgIn: dc.float64[W, H]):
     c1 = 1
     c2 = 1
 
-    y1 = np.empty_like(imgIn)
+    y1 = np.zeros_like(imgIn)
     y1[:, 0] = a1 * imgIn[:, 0]
     y1[:, 1] = a1 * imgIn[:, 1] + a2 * imgIn[:, 0] + b1 * y1[:, 0]
     for j in range(2, H):
         y1[:, j] = (a1 * imgIn[:, j] + a2 * imgIn[:, j - 1] +
                     b1 * y1[:, j - 1] + b2 * y1[:, j - 2])
 
-    y2 = np.empty_like(imgIn)
+    y2 = np.zeros_like(imgIn)
     y2[:, -1] = 0.0
     y2[:, -2] = a3 * imgIn[:, -1]
     for j in range(H - 3, -1, -1):

--- a/npbench/benchmarks/polybench/deriche/deriche_jax.py
+++ b/npbench/benchmarks/polybench/deriche/deriche_jax.py
@@ -15,7 +15,7 @@ def kernel(alpha, imgIn):
     b2 = -jnp.exp(-2.0 * alpha)
     c1 = c2 = 1
 
-    y1 = jnp.empty_like(imgIn)
+    y1 = jnp.zeros_like(imgIn)
     y1 = y1.at[:, 0].set(a1 * imgIn[:, 0])
     y1 = y1.at[:, 1].set(a1 * imgIn[:, 1] + a2 * imgIn[:, 0] + b1 * y1[:, 0])
 
@@ -27,7 +27,7 @@ def kernel(alpha, imgIn):
 
     y1 = lax.fori_loop(2, imgIn.shape[1], horizontal_forward, y1)
 
-    y2 = jnp.empty_like(imgIn)
+    y2 = jnp.zeros_like(imgIn)
     y2 = y2.at[:, -1].set(0.0)
     y2 = y2.at[:, -2].set(a3 * imgIn[:, -1])
 
@@ -42,7 +42,7 @@ def kernel(alpha, imgIn):
 
     imgOut = c1 * (y1 + y2)
 
-    y1 = jnp.empty_like(imgOut)
+    y1 = jnp.zeros_like(imgOut)
     y1 = y1.at[0, :].set(a5 * imgOut[0, :])
     y1 = y1.at[1, :].set(a5 * imgOut[1, :] + a6 * imgOut[0, :] + b1 * y1[0, :])
 
@@ -54,7 +54,7 @@ def kernel(alpha, imgIn):
 
     y1 = lax.fori_loop(2, imgIn.shape[0], vertical_forward, y1)
 
-    y2 = jnp.empty_like(imgOut)
+    y2 = jnp.zeros_like(imgOut)
     y2 = y2.at[-1, :].set(0.0)
     y2 = y2.at[-2, :].set(a7 * imgOut[-1, :])
 

--- a/npbench/benchmarks/polybench/deriche/deriche_legate.py
+++ b/npbench/benchmarks/polybench/deriche/deriche_legate.py
@@ -17,7 +17,7 @@ def kernel(alpha, imgIn):
     b2 = -np.exp(-2.0 * alpha)
     c1 = c2 = 1
 
-    y1 = np.empty_like(imgIn)
+    y1 = np.zeros_like(imgIn)
     y1[:, 0] = a1 * imgIn[:, 0]
     # y1[:, 1] = a1 * imgIn[:, 1] + a2 * imgIn[:, 0] + b1 * y1[:, 0]
     y1[:, 1] = b1 * y1[:, 0]
@@ -26,7 +26,7 @@ def kernel(alpha, imgIn):
         y1[:, j] = (a1 * imgIn[:, j] + a2 * imgIn[:, j - 1] +
                     b1 * y1[:, j - 1] + b2 * y1[:, j - 2])
 
-    y2 = np.empty_like(imgIn)
+    y2 = np.zeros_like(imgIn)
     y2[:, -1] = 0.0
     y2[:, -2] = a3 * imgIn[:, -1]
     for j in range(imgIn.shape[1] - 3, -1, -1):
@@ -55,10 +55,10 @@ def kernel(alpha, imgIn):
 def init_data(W, H, datatype):
 
     alpha = datatype(0.25)
-    imgIn = onp.empty((W, H), dtype=datatype)
-    imgOut = onp.empty((W, H), dtype=datatype)
-    y1 = onp.empty((W, H), dtype=datatype)
-    y2 = onp.empty((W, H), dtype=datatype)
+    imgIn = onp.zeros((W, H), dtype=datatype)
+    imgOut = onp.zeros((W, H), dtype=datatype)
+    y1 = onp.zeros((W, H), dtype=datatype)
+    y2 = onp.zeros((W, H), dtype=datatype)
     for i in range(W):
         for j in range(H):
             imgIn[i, j] = ((313 * i + 991 * j) % 65536) / 65535.0

--- a/npbench/benchmarks/polybench/deriche/deriche_numba_n.py
+++ b/npbench/benchmarks/polybench/deriche/deriche_numba_n.py
@@ -15,14 +15,14 @@ def kernel(alpha, imgIn):
     b2 = -np.exp(-2.0 * alpha)
     c1 = c2 = 1
 
-    y1 = np.empty_like(imgIn)
+    y1 = np.zeros_like(imgIn)
     y1[:, 0] = a1 * imgIn[:, 0]
     y1[:, 1] = a1 * imgIn[:, 1] + a2 * imgIn[:, 0] + b1 * y1[:, 0]
     for j in range(2, imgIn.shape[1]):
         y1[:, j] = (a1 * imgIn[:, j] + a2 * imgIn[:, j - 1] +
                     b1 * y1[:, j - 1] + b2 * y1[:, j - 2])
 
-    y2 = np.empty_like(imgIn)
+    y2 = np.zeros_like(imgIn)
     y2[:, -1] = 0.0
     y2[:, -2] = a3 * imgIn[:, -1]
     for j in range(imgIn.shape[1] - 3, -1, -1):

--- a/npbench/benchmarks/polybench/deriche/deriche_numba_np.py
+++ b/npbench/benchmarks/polybench/deriche/deriche_numba_np.py
@@ -15,14 +15,14 @@ def kernel(alpha, imgIn):
     b2 = -np.exp(-2.0 * alpha)
     c1 = c2 = 1
 
-    y1 = np.empty_like(imgIn)
+    y1 = np.zeros_like(imgIn)
     y1[:, 0] = a1 * imgIn[:, 0]
     y1[:, 1] = a1 * imgIn[:, 1] + a2 * imgIn[:, 0] + b1 * y1[:, 0]
     for j in range(2, imgIn.shape[1]):
         y1[:, j] = (a1 * imgIn[:, j] + a2 * imgIn[:, j - 1] +
                     b1 * y1[:, j - 1] + b2 * y1[:, j - 2])
 
-    y2 = np.empty_like(imgIn)
+    y2 = np.zeros_like(imgIn)
     y2[:, -1] = 0.0
     y2[:, -2] = a3 * imgIn[:, -1]
     for j in range(imgIn.shape[1] - 3, -1, -1):

--- a/npbench/benchmarks/polybench/deriche/deriche_numpy.py
+++ b/npbench/benchmarks/polybench/deriche/deriche_numpy.py
@@ -13,14 +13,14 @@ def kernel(alpha, imgIn):
     b2 = -np.exp(-2.0 * alpha)
     c1 = c2 = 1
 
-    y1 = np.empty_like(imgIn)
+    y1 = np.zeros_like(imgIn)
     y1[:, 0] = a1 * imgIn[:, 0]
     y1[:, 1] = a1 * imgIn[:, 1] + a2 * imgIn[:, 0] + b1 * y1[:, 0]
     for j in range(2, imgIn.shape[1]):
         y1[:, j] = (a1 * imgIn[:, j] + a2 * imgIn[:, j - 1] +
                     b1 * y1[:, j - 1] + b2 * y1[:, j - 2])
 
-    y2 = np.empty_like(imgIn)
+    y2 = np.zeros_like(imgIn)
     y2[:, -1] = 0.0
     y2[:, -2] = a3 * imgIn[:, -1]
     for j in range(imgIn.shape[1] - 3, -1, -1):

--- a/npbench/benchmarks/polybench/deriche/deriche_pythran.py
+++ b/npbench/benchmarks/polybench/deriche/deriche_pythran.py
@@ -14,14 +14,14 @@ def kernel(alpha, imgIn):
     b2 = -np.exp(-2.0 * alpha)
     c1 = c2 = 1
 
-    y1 = np.empty_like(imgIn)
+    y1 = np.zeros_like(imgIn)
     y1[:, 0] = a1 * imgIn[:, 0]
     y1[:, 1] = a1 * imgIn[:, 1] + a2 * imgIn[:, 0] + b1 * y1[:, 0]
     for j in range(2, imgIn.shape[1]):
         y1[:, j] = (a1 * imgIn[:, j] + a2 * imgIn[:, j - 1] +
                     b1 * y1[:, j - 1] + b2 * y1[:, j - 2])
 
-    y2 = np.empty_like(imgIn)
+    y2 = np.zeros_like(imgIn)
     y2[:, -1] = 0.0
     y2[:, -2] = a3 * imgIn[:, -1]
     for j in range(imgIn.shape[1] - 3, -1, -1):

--- a/npbench/benchmarks/polybench/doitgen/doitgen_legate.py
+++ b/npbench/benchmarks/polybench/doitgen/doitgen_legate.py
@@ -16,12 +16,12 @@ def kernel(NR, NQ, NP, A, C4):
 
 def init_data(NR, NQ, NP, datatype):
 
-    A = onp.empty((NR, NQ, NP), dtype=datatype)
-    C4 = onp.empty((
+    A = onp.zeros((NR, NQ, NP), dtype=datatype)
+    C4 = onp.zeros((
         NP,
         NP,
     ), dtype=datatype)
-    sum = onp.empty((NP, ), dtype=datatype)
+    sum = onp.zeros((NP, ), dtype=datatype)
     for i in range(NR):
         for j in range(NQ):
             for k in range(NP):

--- a/npbench/benchmarks/polybench/durbin/durbin_cupy.py
+++ b/npbench/benchmarks/polybench/durbin/durbin_cupy.py
@@ -3,7 +3,7 @@ import cupy as np
 
 def kernel(r):
 
-    y = np.empty_like(r)
+    y = np.zeros_like(r)
     alpha = -r[0]
     beta = 1.0
     y[0] = -r[0]

--- a/npbench/benchmarks/polybench/durbin/durbin_dace.py
+++ b/npbench/benchmarks/polybench/durbin/durbin_dace.py
@@ -15,7 +15,7 @@ def flip(A: dc.float64[M]):
 @dc.program
 def kernel(r: dc.float64[N]):
 
-    y = np.empty_like(r)
+    y = np.zeros_like(r)
     alpha = -r[0]
     beta = 1.0
     y[0] = -r[0]

--- a/npbench/benchmarks/polybench/durbin/durbin_jax.py
+++ b/npbench/benchmarks/polybench/durbin/durbin_jax.py
@@ -6,7 +6,7 @@ from jax import lax
 @jax.jit
 def kernel(r):
 
-    y = jnp.empty_like(r)
+    y = jnp.zeros_like(r)
     alpha = -r[0]
     beta = 1.0
     y = y.at[0].set(-r[0])

--- a/npbench/benchmarks/polybench/durbin/durbin_legate.py
+++ b/npbench/benchmarks/polybench/durbin/durbin_legate.py
@@ -7,7 +7,7 @@ import durbin_numpy as np_impl
 
 def kernel(r):
 
-    y = np.empty_like(r)
+    y = np.zeros_like(r)
     alpha = -r[0]
     beta = 1.0
     y[0] = -r[0]
@@ -25,8 +25,8 @@ def kernel(r):
 
 def init_data(N, datatype):
 
-    r = onp.empty((N, ), dtype=datatype)
-    y = onp.empty((N, ), dtype=datatype)
+    r = onp.zeros((N, ), dtype=datatype)
+    y = onp.zeros((N, ), dtype=datatype)
     for i in range(N):
         r[i] = N + 1 - i
 

--- a/npbench/benchmarks/polybench/durbin/durbin_numba_n.py
+++ b/npbench/benchmarks/polybench/durbin/durbin_numba_n.py
@@ -5,7 +5,7 @@ import numba as nb
 @nb.jit(nopython=True, parallel=False, fastmath=True)
 def kernel(r):
 
-    y = np.empty_like(r)
+    y = np.zeros_like(r)
     alpha = -r[0]
     beta = 1.0
     y[0] = -r[0]

--- a/npbench/benchmarks/polybench/durbin/durbin_numba_np.py
+++ b/npbench/benchmarks/polybench/durbin/durbin_numba_np.py
@@ -5,7 +5,7 @@ import numba as nb
 @nb.jit(nopython=True, parallel=True, fastmath=True)
 def kernel(r):
 
-    y = np.empty_like(r)
+    y = np.zeros_like(r)
     alpha = -r[0]
     beta = 1.0
     y[0] = -r[0]

--- a/npbench/benchmarks/polybench/durbin/durbin_numpy.py
+++ b/npbench/benchmarks/polybench/durbin/durbin_numpy.py
@@ -3,7 +3,7 @@ import numpy as np
 
 def kernel(r):
 
-    y = np.empty_like(r)
+    y = np.zeros_like(r)
     alpha = -r[0]
     beta = 1.0
     y[0] = -r[0]

--- a/npbench/benchmarks/polybench/durbin/durbin_pythran.py
+++ b/npbench/benchmarks/polybench/durbin/durbin_pythran.py
@@ -2,7 +2,7 @@ import numpy as np
 
 
 def flip(A):
-    B = np.empty_like(A)
+    B = np.zeros_like(A)
     for i in range(B.shape[0]):
         B[i] = A[-1 - i]
     return B
@@ -11,7 +11,7 @@ def flip(A):
 # pythran export kernel(float64[:])
 def kernel(r):
 
-    y = np.empty_like(r)
+    y = np.zeros_like(r)
     alpha = -r[0]
     beta = 1.0
     y[0] = -r[0]

--- a/npbench/benchmarks/polybench/gemm/gemm_legate.py
+++ b/npbench/benchmarks/polybench/gemm/gemm_legate.py
@@ -13,17 +13,17 @@ def init_data(NI, NJ, NK, datatype):
 
     alpha = datatype(1.5)
     beta = datatype(1.2)
-    C = np.empty((NI, NJ), dtype=datatype)
+    C = np.zeros((NI, NJ), dtype=datatype)
     # for i in range(NI):
     #     for j in range(NJ):
     #         C[i, j] = ((i * j + 1) % NI) / NI
     C[:] = np.random.randn(NI, NJ)
-    A = np.empty((NI, NK), dtype=datatype)
+    A = np.zeros((NI, NK), dtype=datatype)
     # for i in range(NI):
     #     for k in range(NK):
     #         A[i, k] = (i * (k + 1) % NK) / NK
     A[:] = np.random.randn(NI, NK)
-    B = np.empty((NK, NJ), dtype=datatype)
+    B = np.zeros((NK, NJ), dtype=datatype)
     # for k in range(NK):
     #     for j in range(NJ):
     #         C[i, j] = (k * (j + 2) % NJ) / NJ

--- a/npbench/benchmarks/polybench/gramschmidt/gramschmidt.py
+++ b/npbench/benchmarks/polybench/gramschmidt/gramschmidt.py
@@ -8,7 +8,11 @@ def initialize(M, N, datatype=np.float64):
     rng = default_rng(42)
 
     A = rng.random((M, N), dtype=datatype)
-    while np.linalg.matrix_rank(A) < N:
-        A = rng.random((M, N), dtype=datatype)
+    # Add a diagonal-dominance term so A is deterministically full column rank and
+    # well-conditioned. A plain random matrix is only full-rank in expectation (hence the
+    # former reject-sampling ``while matrix_rank(A) < N`` loop) and can still be poorly
+    # conditioned, which makes the Gram-Schmidt QR numerically unstable; the added diagonal
+    # gives cond(A) ~= 1.5 without the nondeterministic resampling.
+    A[:N, :N] += N * np.eye(N, dtype=datatype)
 
     return A

--- a/npbench/benchmarks/polybench/k2mm/k2mm_legate.py
+++ b/npbench/benchmarks/polybench/k2mm/k2mm_legate.py
@@ -11,11 +11,11 @@ def init_data(NI, NJ, NK, NL, datatype):
 
     alpha = datatype(1.5)
     beta = datatype(1.2)
-    tmp = np.empty((NI, NJ), dtype=datatype)
-    A = np.empty((NI, NK), dtype=datatype)
-    B = np.empty((NK, NJ), dtype=datatype)
-    C = np.empty((NJ, NL), dtype=datatype)
-    D = np.empty((NI, NL), dtype=datatype)
+    tmp = np.zeros((NI, NJ), dtype=datatype)
+    A = np.zeros((NI, NK), dtype=datatype)
+    B = np.zeros((NK, NJ), dtype=datatype)
+    C = np.zeros((NJ, NL), dtype=datatype)
+    D = np.zeros((NI, NL), dtype=datatype)
     # for i in range(NI):
     #     for j in range(NK):
     #         A[i, j] = ((i * j + 1) % NI) / NI

--- a/npbench/benchmarks/polybench/k3mm/k3mm_legate.py
+++ b/npbench/benchmarks/polybench/k3mm/k3mm_legate.py
@@ -47,13 +47,13 @@ def kernel(A, B, C, D):
 
 def init_data(NI, NJ, NK, NL, NM, datatype):
 
-    E = np.empty((NI, NJ), dtype=datatype)
-    A = np.empty((NI, NK), dtype=datatype)
-    B = np.empty((NK, NJ), dtype=datatype)
-    F = np.empty((NJ, NL), dtype=datatype)
-    C = np.empty((NJ, NM), dtype=datatype)
-    D = np.empty((NM, NL), dtype=datatype)
-    G = np.empty((NI, NL), dtype=datatype)
+    E = np.zeros((NI, NJ), dtype=datatype)
+    A = np.zeros((NI, NK), dtype=datatype)
+    B = np.zeros((NK, NJ), dtype=datatype)
+    F = np.zeros((NJ, NL), dtype=datatype)
+    C = np.zeros((NJ, NM), dtype=datatype)
+    D = np.zeros((NM, NL), dtype=datatype)
+    G = np.zeros((NI, NL), dtype=datatype)
     # for i in range(NI):
     #     for j in range(NK):
     #         A[i, j] = ((i * j + 1) % NI) / (5 * NI)

--- a/npbench/benchmarks/polybench/lu/lu.py
+++ b/npbench/benchmarks/polybench/lu/lu.py
@@ -4,7 +4,7 @@ import numpy as np
 
 
 def initialize(N, datatype=np.float64):
-    A = np.empty((N, N), dtype=datatype)
+    A = np.zeros((N, N), dtype=datatype)
     for i in range(N):
         A[i, :i + 1] = np.fromfunction(lambda j: (-j % N) / N + 1, (i + 1, ),
                                        dtype=datatype)

--- a/npbench/benchmarks/polybench/ludcmp/ludcmp.py
+++ b/npbench/benchmarks/polybench/ludcmp/ludcmp.py
@@ -4,7 +4,7 @@ import numpy as np
 
 
 def initialize(N, datatype=np.float64):
-    A = np.empty((N, N), dtype=datatype)
+    A = np.zeros((N, N), dtype=datatype)
     for i in range(N):
         A[i, :i + 1] = np.fromfunction(lambda j: (-j % N) / N + 1, (i + 1, ),
                                        dtype=datatype)

--- a/npbench/benchmarks/polybench/symm/symm.py
+++ b/npbench/benchmarks/polybench/symm/symm.py
@@ -10,7 +10,7 @@ def initialize(M, N, datatype=np.float64):
                         dtype=datatype)
     B = np.fromfunction(lambda i, j: ((N + i - j) % 100) / M, (M, N),
                         dtype=datatype)
-    A = np.empty((M, M), dtype=datatype)
+    A = np.zeros((M, M), dtype=datatype)
     for i in range(M):
         A[i, :i + 1] = np.fromfunction(lambda j: ((i + j) % 100) / M,
                                        (i + 1, ),

--- a/npbench/benchmarks/polybench/symm/symm_cupy.py
+++ b/npbench/benchmarks/polybench/symm/symm_cupy.py
@@ -3,7 +3,7 @@ import cupy as np
 
 def kernel(alpha, beta, C, A, B):
 
-    temp2 = np.empty((C.shape[1], ), dtype=C.dtype)
+    temp2 = np.zeros((C.shape[1], ), dtype=C.dtype)
     C *= beta
     for i in range(C.shape[0]):
         for j in range(C.shape[1]):

--- a/npbench/benchmarks/polybench/symm/symm_dace.py
+++ b/npbench/benchmarks/polybench/symm/symm_dace.py
@@ -8,7 +8,7 @@ M, N = (dc.symbol(s, dtype=dc.int64) for s in ('M', 'N'))
 def kernel(alpha: dc.float64, beta: dc.float64, C: dc.float64[M, N],
            A: dc.float64[M, M], B: dc.float64[M, N]):
 
-    temp2 = np.empty((N, ), dtype=C.dtype)
+    temp2 = np.zeros((N, ), dtype=C.dtype)
     C *= beta
     for i in range(M):
         for j in range(N):

--- a/npbench/benchmarks/polybench/symm/symm_jax.py
+++ b/npbench/benchmarks/polybench/symm/symm_jax.py
@@ -5,7 +5,7 @@ from jax import lax
 @jax.jit
 def kernel(alpha, beta, C: jax.Array, A: jax.Array, B: jax.Array):
 
-    temp2 = jnp.empty((C.shape[1], ), dtype=C.dtype)
+    temp2 = jnp.zeros((C.shape[1], ), dtype=C.dtype)
     C *= beta
 
     def row_update(i, arrays):

--- a/npbench/benchmarks/polybench/symm/symm_numba_n.py
+++ b/npbench/benchmarks/polybench/symm/symm_numba_n.py
@@ -5,7 +5,7 @@ import numba as nb
 @nb.jit(nopython=True, parallel=False, fastmath=True)
 def kernel(alpha, beta, C, A, B):
 
-    temp2 = np.empty((C.shape[1], ), dtype=C.dtype)
+    temp2 = np.zeros((C.shape[1], ), dtype=C.dtype)
     C *= beta
     for i in range(C.shape[0]):
         for j in range(C.shape[1]):

--- a/npbench/benchmarks/polybench/symm/symm_numba_npr.py
+++ b/npbench/benchmarks/polybench/symm/symm_numba_npr.py
@@ -5,7 +5,7 @@ import numba as nb
 @nb.jit(nopython=True, parallel=True, fastmath=True)
 def kernel(alpha, beta, C, A, B):
 
-    temp2 = np.empty((C.shape[1], ), dtype=C.dtype)
+    temp2 = np.zeros((C.shape[1], ), dtype=C.dtype)
     C *= beta
     for i in range(C.shape[0]):
         for j in nb.prange(C.shape[1]):

--- a/npbench/benchmarks/polybench/symm/symm_numpy.py
+++ b/npbench/benchmarks/polybench/symm/symm_numpy.py
@@ -3,7 +3,7 @@ import numpy as np
 
 def kernel(alpha, beta, C, A, B):
 
-    temp2 = np.empty((C.shape[1], ), dtype=C.dtype)
+    temp2 = np.zeros((C.shape[1], ), dtype=C.dtype)
     C *= beta
     for i in range(C.shape[0]):
         for j in range(C.shape[1]):

--- a/npbench/benchmarks/polybench/symm/symm_pythran.py
+++ b/npbench/benchmarks/polybench/symm/symm_pythran.py
@@ -4,7 +4,7 @@ import numpy as np
 # pythran export kernel(float64, float64, float64[:,:], float64[:,:], float64[:,:])
 def kernel(alpha, beta, C, A, B):
 
-    temp2 = np.empty((C.shape[1], ), dtype=C.dtype)
+    temp2 = np.zeros((C.shape[1], ), dtype=C.dtype)
     C *= beta
     for i in range(C.shape[0]):
         for j in range(C.shape[1]):

--- a/npbench/benchmarks/spmv/spmv_cupy.py
+++ b/npbench/benchmarks/spmv/spmv_cupy.py
@@ -5,7 +5,7 @@ import cupy as np
 # Matrix-Vector Multiplication with the matrix given in Compressed Sparse Row
 # (CSR) format
 def spmv(A_row, A_col, A_val, x):
-    y = np.empty(A_row.size - 1, A_val.dtype)
+    y = np.zeros(A_row.size - 1, A_val.dtype)
 
     for i in range(A_row.size - 1):
         cols = A_col[A_row[i]:A_row[i + 1]]

--- a/npbench/benchmarks/spmv/spmv_dace.py
+++ b/npbench/benchmarks/spmv/spmv_dace.py
@@ -11,7 +11,7 @@ M, N, nnz = (dc.symbol(s, dtype=dc.int64) for s in ('M', 'N', 'nnz'))
 def spmv(A_row: dc.uint32[M + 1], A_col: dc.uint32[nnz],
          A_val: dc.float64[nnz], x: dc.float64[N]):
     # y = np.empty(A_row.size - 1, A_val.dtype)
-    y = np.empty(M, A_val.dtype)
+    y = np.zeros(M, A_val.dtype)
 
     # for i in range(A_row.size - 1):
     for i in range(M):

--- a/npbench/benchmarks/spmv/spmv_jax.py
+++ b/npbench/benchmarks/spmv/spmv_jax.py
@@ -7,7 +7,7 @@ from jax import lax
 # (CSR) format
 @jax.jit
 def spmv(A_row, A_col, A_val, x):
-    y = jnp.empty(A_row.size - 1, dtype=A_val.dtype)
+    y = jnp.zeros(A_row.size - 1, dtype=A_val.dtype)
 
     def row_update(i, y):
 

--- a/npbench/benchmarks/spmv/spmv_numba_n.py
+++ b/npbench/benchmarks/spmv/spmv_numba_n.py
@@ -7,7 +7,7 @@ import numba as nb
 # (CSR) format
 @nb.jit(nopython=True, parallel=False, fastmath=True)
 def spmv(A_row, A_col, A_val, x):
-    y = np.empty(A_row.size - 1, A_val.dtype)
+    y = np.zeros(A_row.size - 1, A_val.dtype)
 
     for i in range(A_row.size - 1):
         cols = A_col[A_row[i]:A_row[i + 1]]

--- a/npbench/benchmarks/spmv/spmv_numba_np.py
+++ b/npbench/benchmarks/spmv/spmv_numba_np.py
@@ -7,7 +7,7 @@ import numba as nb
 # (CSR) format
 @nb.jit(nopython=True, parallel=True, fastmath=True)
 def spmv(A_row, A_col, A_val, x):
-    y = np.empty(A_row.size - 1, A_val.dtype)
+    y = np.zeros(A_row.size - 1, A_val.dtype)
 
     for i in range(A_row.size - 1):
         cols = A_col[A_row[i]:A_row[i + 1]]

--- a/npbench/benchmarks/spmv/spmv_numba_npr.py
+++ b/npbench/benchmarks/spmv/spmv_numba_npr.py
@@ -7,7 +7,7 @@ import numba as nb
 # (CSR) format
 @nb.jit(nopython=True, parallel=True, fastmath=True)
 def spmv(A_row, A_col, A_val, x):
-    y = np.empty(A_row.size - 1, A_val.dtype)
+    y = np.zeros(A_row.size - 1, A_val.dtype)
 
     for i in nb.prange(A_row.size - 1):
         cols = A_col[A_row[i]:A_row[i + 1]]

--- a/npbench/benchmarks/spmv/spmv_numpy.py
+++ b/npbench/benchmarks/spmv/spmv_numpy.py
@@ -5,7 +5,7 @@ import numpy as np
 # Matrix-Vector Multiplication with the matrix given in Compressed Sparse Row
 # (CSR) format
 def spmv(A_row, A_col, A_val, x):
-    y = np.empty(A_row.size - 1, A_val.dtype)
+    y = np.zeros(A_row.size - 1, A_val.dtype)
 
     for i in range(A_row.size - 1):
         cols = A_col[A_row[i]:A_row[i + 1]]

--- a/npbench/benchmarks/spmv/spmv_pythran.py
+++ b/npbench/benchmarks/spmv/spmv_pythran.py
@@ -6,7 +6,7 @@ import numpy as np
 # (CSR) format
 # pythran export spmv(uint32[:], uint32[:], float64[:], float64[:])
 def spmv(A_row, A_col, A_val, x):
-    y = np.empty(A_row.size - 1, A_val.dtype)
+    y = np.zeros(A_row.size - 1, A_val.dtype)
 
     for i in range(A_row.size - 1):
         cols = A_col[A_row[i]:A_row[i + 1]]

--- a/npbench/benchmarks/stockham_fft/stockham_fft_cupy.py
+++ b/npbench/benchmarks/stockham_fft/stockham_fft_cupy.py
@@ -6,7 +6,7 @@ def stockham_fft(N, R, K, x, y):
     # Generate DFT matrix for radix R.
     # Define transient variable for matrix.
     i_coord, j_coord = np.mgrid[0:R, 0:R]
-    dft_mat = np.empty((R, R), dtype=np.complex128)
+    dft_mat = np.zeros((R, R), dtype=np.complex128)
     dft_mat = np.exp(-2.0j * np.pi * i_coord * j_coord / R)
     # Move input x to output y
     # to avoid overwriting the input.
@@ -21,7 +21,7 @@ def stockham_fft(N, R, K, x, y):
         yv = np.reshape(y, (R**i, R, R**(K - i - 1)))
         tmp_perm = np.transpose(yv, axes=(1, 0, 2))
         # Twiddle Factor multiplication
-        D = np.empty((R, R**i, R**(K - i - 1)), dtype=np.complex128)
+        D = np.zeros((R, R**i, R**(K - i - 1)), dtype=np.complex128)
         tmp = np.exp(-2.0j * np.pi * ii_coord[:, :R**i] * jj_coord[:, :R**i] /
                      R**(i + 1))
         D[:] = np.repeat(np.reshape(tmp, (R, R**i, 1)), R**(K - i - 1), axis=2)

--- a/npbench/benchmarks/stockham_fft/stockham_fft_dace.py
+++ b/npbench/benchmarks/stockham_fft/stockham_fft_dace.py
@@ -35,7 +35,7 @@ def stockham_fft(x: dc.complex128[R**K], y: dc.complex128[R**K]):
     i_coord = np.ndarray((R, R), dtype=np.uint32)
     j_coord = np.ndarray((R, R), dtype=np.uint32)
     mgrid1(i_coord, j_coord)
-    dft_mat = np.empty((R, R), dtype=np.complex128)
+    dft_mat = np.zeros((R, R), dtype=np.complex128)
     dft_mat[:] = np.exp(-2.0j * np.pi * i_coord * j_coord / R)
     # Move input x to output y
     # to avoid overwriting the input.
@@ -46,9 +46,9 @@ def stockham_fft(x: dc.complex128[R**K], y: dc.complex128[R**K]):
     jj_coord = np.ndarray((R, N), dtype=np.uint32)
     mgrid2(ii_coord, jj_coord)
 
-    tmp_perm = np.empty_like(y)
-    D = np.empty_like(y)
-    tmp = np.empty_like(y)
+    tmp_perm = np.zeros_like(y)
+    D = np.zeros_like(y)
+    tmp = np.zeros_like(y)
 
     # Main Stockham loop
     for i in range(K):

--- a/npbench/benchmarks/stockham_fft/stockham_fft_dpnp.py
+++ b/npbench/benchmarks/stockham_fft/stockham_fft_dpnp.py
@@ -5,7 +5,7 @@ def stockham_fft(N, R, K, x, y):
     # Generate DFT matrix for radix R.
     # Define transient variable for matrix.
     i_coord, j_coord = np.mgrid[0:R, 0:R]
-    dft_mat = np.empty((R, R), dtype=np.complex128)
+    dft_mat = np.zeros((R, R), dtype=np.complex128)
     dft_mat = np.exp(-2.0j * np.pi * i_coord * j_coord / R)
     # Move input x to output y to avoid overwriting the input.
 #    y[:] = x[:]
@@ -19,7 +19,7 @@ def stockham_fft(N, R, K, x, y):
         yv = np.reshape(y, (R**i, R, R**(K - i - 1)))
         tmp_perm = np.transpose(yv, axes=(1, 0, 2))
         # Twiddle Factor multiplication
-        D = np.empty((R, R**i, R**(K - i - 1)), dtype=np.complex128)
+        D = np.zeros((R, R**i, R**(K - i - 1)), dtype=np.complex128)
         tmp = np.exp(-2.0j * np.pi * ii_coord[:, :R**i] * jj_coord[:, :R**i] /
                      R**(i + 1))
         np.copyto(D, np.repeat(np.reshape(tmp, (R, R**i, 1)), R**(K - i - 1), axis=2))

--- a/npbench/benchmarks/stockham_fft/stockham_fft_numba_n.py
+++ b/npbench/benchmarks/stockham_fft/stockham_fft_numba_n.py
@@ -4,8 +4,8 @@ import numba as nb
 
 @nb.jit(nopython=True, parallel=False, fastmath=True)
 def mgrid(xn, yn):
-    Xi = np.empty((xn, yn), dtype=np.uint32)
-    Yi = np.empty((xn, yn), dtype=np.uint32)
+    Xi = np.zeros((xn, yn), dtype=np.uint32)
+    Yi = np.zeros((xn, yn), dtype=np.uint32)
     for i in range(xn):
         Xi[i, :] = i
     for j in range(yn):
@@ -19,7 +19,7 @@ def stockham_fft(N, R, K, x, y):
     # Generate DFT matrix for radix R.
     # Define transient variable for matrix.
     i_coord, j_coord = mgrid(R, R)
-    dft_mat = np.empty((R, R), dtype=np.complex128)
+    dft_mat = np.zeros((R, R), dtype=np.complex128)
     dft_mat = np.exp(-2.0j * np.pi * i_coord * j_coord / R)
     # Move input x to output y
     # to avoid overwriting the input.
@@ -36,7 +36,7 @@ def stockham_fft(N, R, K, x, y):
         # tmp_perm = np.transpose(yv, axes=(1, 0, 2))
         tmp_perm = np.transpose(yv, axes=(1, 0, 2)).copy()
         # Twiddle Factor multiplication
-        D = np.empty((R, R**i, R**(K - i - 1)), dtype=np.complex128)
+        D = np.zeros((R, R**i, R**(K - i - 1)), dtype=np.complex128)
         tmp = np.exp(-2.0j * np.pi * ii_coord[:, :R**i] * jj_coord[:, :R**i] /
                      R**(i + 1))
         # D[:] = np.repeat(np.reshape(tmp, (R, R**i, 1)), R ** (K-i-1), axis=2)

--- a/npbench/benchmarks/stockham_fft/stockham_fft_numba_np.py
+++ b/npbench/benchmarks/stockham_fft/stockham_fft_numba_np.py
@@ -4,8 +4,8 @@ import numba as nb
 
 @nb.jit(nopython=True, parallel=True, fastmath=True)
 def mgrid(xn, yn):
-    Xi = np.empty((xn, yn), dtype=np.uint32)
-    Yi = np.empty((xn, yn), dtype=np.uint32)
+    Xi = np.zeros((xn, yn), dtype=np.uint32)
+    Yi = np.zeros((xn, yn), dtype=np.uint32)
     for i in range(xn):
         Xi[i, :] = i
     for j in range(yn):
@@ -19,7 +19,7 @@ def stockham_fft(N, R, K, x, y):
     # Generate DFT matrix for radix R.
     # Define transient variable for matrix.
     i_coord, j_coord = mgrid(R, R)
-    dft_mat = np.empty((R, R), dtype=np.complex128)
+    dft_mat = np.zeros((R, R), dtype=np.complex128)
     dft_mat = np.exp(-2.0j * np.pi * i_coord * j_coord / R)
     # Move input x to output y
     # to avoid overwriting the input.
@@ -36,7 +36,7 @@ def stockham_fft(N, R, K, x, y):
         # tmp_perm = np.transpose(yv, axes=(1, 0, 2))
         tmp_perm = np.transpose(yv, axes=(1, 0, 2)).copy()
         # Twiddle Factor multiplication
-        D = np.empty((R, R**i, R**(K - i - 1)), dtype=np.complex128)
+        D = np.zeros((R, R**i, R**(K - i - 1)), dtype=np.complex128)
         tmp = np.exp(-2.0j * np.pi * ii_coord[:, :R**i] * jj_coord[:, :R**i] /
                      R**(i + 1))
         # D[:] = np.repeat(np.reshape(tmp, (R, R**i, 1)), R ** (K-i-1), axis=2)

--- a/npbench/benchmarks/stockham_fft/stockham_fft_numba_npr.py
+++ b/npbench/benchmarks/stockham_fft/stockham_fft_numba_npr.py
@@ -4,8 +4,8 @@ import numba as nb
 
 @nb.jit(nopython=True, parallel=True, fastmath=True)
 def mgrid(xn, yn):
-    Xi = np.empty((xn, yn), dtype=np.uint32)
-    Yi = np.empty((xn, yn), dtype=np.uint32)
+    Xi = np.zeros((xn, yn), dtype=np.uint32)
+    Yi = np.zeros((xn, yn), dtype=np.uint32)
     for i in nb.prange(xn):
         Xi[i, :] = i
     for j in nb.prange(yn):
@@ -19,7 +19,7 @@ def stockham_fft(N, R, K, x, y):
     # Generate DFT matrix for radix R.
     # Define transient variable for matrix.
     i_coord, j_coord = mgrid(R, R)
-    dft_mat = np.empty((R, R), dtype=np.complex128)
+    dft_mat = np.zeros((R, R), dtype=np.complex128)
     dft_mat = np.exp(-2.0j * np.pi * i_coord * j_coord / R)
     # Move input x to output y
     # to avoid overwriting the input.
@@ -36,7 +36,7 @@ def stockham_fft(N, R, K, x, y):
         # tmp_perm = np.transpose(yv, axes=(1, 0, 2))
         tmp_perm = np.transpose(yv, axes=(1, 0, 2)).copy()
         # Twiddle Factor multiplication
-        D = np.empty((R, R**i, R**(K - i - 1)), dtype=np.complex128)
+        D = np.zeros((R, R**i, R**(K - i - 1)), dtype=np.complex128)
         tmp = np.exp(-2.0j * np.pi * ii_coord[:, :R**i] * jj_coord[:, :R**i] /
                      R**(i + 1))
         # D[:] = np.repeat(np.reshape(tmp, (R, R**i, 1)), R ** (K-i-1), axis=2)

--- a/npbench/benchmarks/stockham_fft/stockham_fft_numba_o.py
+++ b/npbench/benchmarks/stockham_fft/stockham_fft_numba_o.py
@@ -8,7 +8,7 @@ def stockham_fft(N, R, K, x, y):
     # Generate DFT matrix for radix R.
     # Define transient variable for matrix.
     i_coord, j_coord = np.mgrid[0:R, 0:R]
-    dft_mat = np.empty((R, R), dtype=np.complex128)
+    dft_mat = np.zeros((R, R), dtype=np.complex128)
     dft_mat = np.exp(-2.0j * np.pi * i_coord * j_coord / R)
     # Move input x to output y
     # to avoid overwriting the input.
@@ -23,7 +23,7 @@ def stockham_fft(N, R, K, x, y):
         yv = np.reshape(y, (R**i, R, R**(K - i - 1)))
         tmp_perm = np.transpose(yv, axes=(1, 0, 2))
         # Twiddle Factor multiplication
-        D = np.empty((R, R**i, R**(K - i - 1)), dtype=np.complex128)
+        D = np.zeros((R, R**i, R**(K - i - 1)), dtype=np.complex128)
         tmp = np.exp(-2.0j * np.pi * ii_coord[:, :R**i] * jj_coord[:, :R**i] /
                      R**(i + 1))
         D[:] = np.repeat(np.reshape(tmp, (R, R**i, 1)), R**(K - i - 1), axis=2)

--- a/npbench/benchmarks/stockham_fft/stockham_fft_numba_op.py
+++ b/npbench/benchmarks/stockham_fft/stockham_fft_numba_op.py
@@ -8,7 +8,7 @@ def stockham_fft(N, R, K, x, y):
     # Generate DFT matrix for radix R.
     # Define transient variable for matrix.
     i_coord, j_coord = np.mgrid[0:R, 0:R]
-    dft_mat = np.empty((R, R), dtype=np.complex128)
+    dft_mat = np.zeros((R, R), dtype=np.complex128)
     dft_mat = np.exp(-2.0j * np.pi * i_coord * j_coord / R)
     # Move input x to output y
     # to avoid overwriting the input.
@@ -23,7 +23,7 @@ def stockham_fft(N, R, K, x, y):
         yv = np.reshape(y, (R**i, R, R**(K - i - 1)))
         tmp_perm = np.transpose(yv, axes=(1, 0, 2))
         # Twiddle Factor multiplication
-        D = np.empty((R, R**i, R**(K - i - 1)), dtype=np.complex128)
+        D = np.zeros((R, R**i, R**(K - i - 1)), dtype=np.complex128)
         tmp = np.exp(-2.0j * np.pi * ii_coord[:, :R**i] * jj_coord[:, :R**i] /
                      R**(i + 1))
         D[:] = np.repeat(np.reshape(tmp, (R, R**i, 1)), R**(K - i - 1), axis=2)

--- a/npbench/benchmarks/stockham_fft/stockham_fft_numpy.py
+++ b/npbench/benchmarks/stockham_fft/stockham_fft_numpy.py
@@ -6,7 +6,7 @@ def stockham_fft(N, R, K, x, y):
     # Generate DFT matrix for radix R.
     # Define transient variable for matrix.
     i_coord, j_coord = np.mgrid[0:R, 0:R]
-    dft_mat = np.empty((R, R), dtype=np.complex128)
+    dft_mat = np.zeros((R, R), dtype=np.complex128)
     dft_mat = np.exp(-2.0j * np.pi * i_coord * j_coord / R)
     # Move input x to output y
     # to avoid overwriting the input.
@@ -21,7 +21,7 @@ def stockham_fft(N, R, K, x, y):
         yv = np.reshape(y, (R**i, R, R**(K - i - 1)))
         tmp_perm = np.transpose(yv, axes=(1, 0, 2))
         # Twiddle Factor multiplication
-        D = np.empty((R, R**i, R**(K - i - 1)), dtype=np.complex128)
+        D = np.zeros((R, R**i, R**(K - i - 1)), dtype=np.complex128)
         tmp = np.exp(-2.0j * np.pi * ii_coord[:, :R**i] * jj_coord[:, :R**i] /
                      R**(i + 1))
         D[:] = np.repeat(np.reshape(tmp, (R, R**i, 1)), R**(K - i - 1), axis=2)

--- a/npbench/benchmarks/stockham_fft/stockham_fft_pythran.py
+++ b/npbench/benchmarks/stockham_fft/stockham_fft_pythran.py
@@ -3,8 +3,8 @@ import numpy as np
 
 # pythran export mgrid(int, int)
 def mgrid(xn, yn):
-    Xi = np.empty((xn, yn), dtype=np.uint32)
-    Yi = np.empty((xn, yn), dtype=np.uint32)
+    Xi = np.zeros((xn, yn), dtype=np.uint32)
+    Yi = np.zeros((xn, yn), dtype=np.uint32)
     for i in range(xn):
         Xi[i, :] = i
     for j in range(yn):
@@ -19,7 +19,7 @@ def stockham_fft(N, R, K, x, y):
     # Define transient variable for matrix.
     # i_coord, j_coord = np.mgrid[0:R, 0:R]
     i_coord, j_coord = mgrid(R, R)
-    dft_mat = np.empty((R, R), dtype=np.complex128)
+    dft_mat = np.zeros((R, R), dtype=np.complex128)
     dft_mat = np.exp(-2.0j * np.pi * i_coord * j_coord / R)
     # Move input x to output y
     # to avoid overwriting the input.
@@ -36,7 +36,7 @@ def stockham_fft(N, R, K, x, y):
         yv = y.reshape(R**i, R, R**(K - i - 1))
         tmp_perm = np.transpose(yv, axes=(1, 0, 2))
         # Twiddle Factor multiplication
-        D = np.empty((R, R**i, R**(K - i - 1)), dtype=np.complex128)
+        D = np.zeros((R, R**i, R**(K - i - 1)), dtype=np.complex128)
         tmp = np.exp(-2.0j * np.pi * ii_coord[:, :R**i] * jj_coord[:, :R**i] /
                      R**(i + 1))
         # D[:] = np.repeat(np.reshape(tmp, (R, R**i, 1)), R ** (K-i-1), axis=2)

--- a/npbench/benchmarks/weather_stencils/vadv/vadv_dpnp.py
+++ b/npbench/benchmarks/weather_stencils/vadv/vadv_dpnp.py
@@ -7,9 +7,9 @@ BET_P = 0.5
 # Adapted and optimized for runtime efficiency
 def vadv(utens_stage, u_stage, wcon, u_pos, utens, dtr_stage):
     I, J, K = utens_stage.shape[0], utens_stage.shape[1], utens_stage.shape[2]
-    ccol = np.empty((I, J, K), dtype=utens_stage.dtype)
-    dcol = np.empty((I, J, K), dtype=utens_stage.dtype)
-    data_col = np.empty((I, J), dtype=utens_stage.dtype)
+    ccol = np.zeros((I, J, K), dtype=utens_stage.dtype)
+    dcol = np.zeros((I, J, K), dtype=utens_stage.dtype)
+    data_col = np.zeros((I, J), dtype=utens_stage.dtype)
 
     # Use np.sum for slicing and cumulative operations
     for k in range(1):

--- a/npbench/benchmarks/weather_stencils/vadv/vadv_jax.py
+++ b/npbench/benchmarks/weather_stencils/vadv/vadv_jax.py
@@ -10,9 +10,9 @@ BET_P = 0.5
 @jax.jit
 def vadv(utens_stage, u_stage, wcon, u_pos, utens, dtr_stage):
     I, J, K = utens_stage.shape[0], utens_stage.shape[1], utens_stage.shape[2]
-    ccol = jnp.empty((I, J, K), dtype=utens_stage.dtype)
-    dcol = jnp.empty((I, J, K), dtype=utens_stage.dtype)
-    data_col = jnp.empty((I, J), dtype=utens_stage.dtype)
+    ccol = jnp.zeros((I, J, K), dtype=utens_stage.dtype)
+    dcol = jnp.zeros((I, J, K), dtype=utens_stage.dtype)
+    data_col = jnp.zeros((I, J), dtype=utens_stage.dtype)
 
     def loop1(k, loop_vars):
         ccol, dcol = loop_vars

--- a/npbench/benchmarks/weather_stencils/vadv/vadv_numba_n.py
+++ b/npbench/benchmarks/weather_stencils/vadv/vadv_numba_n.py
@@ -13,9 +13,9 @@ def vadv(utens_stage, u_stage, wcon, u_pos, utens, dtr_stage):
     # ccol = np.ndarray((I, J, K), dtype=utens_stage.dtype)
     # dcol = np.ndarray((I, J, K), dtype=utens_stage.dtype)
     # data_col = np.ndarray((I, J), dtype=utens_stage.dtype)
-    ccol = np.empty((I, J, K), dtype=utens_stage.dtype)
-    dcol = np.empty((I, J, K), dtype=utens_stage.dtype)
-    data_col = np.empty((I, J), dtype=utens_stage.dtype)
+    ccol = np.zeros((I, J, K), dtype=utens_stage.dtype)
+    dcol = np.zeros((I, J, K), dtype=utens_stage.dtype)
+    data_col = np.zeros((I, J), dtype=utens_stage.dtype)
 
     for k in range(1):
         gcv = 0.25 * (wcon[1:, :, k + 1] + wcon[:-1, :, k + 1])

--- a/npbench/benchmarks/weather_stencils/vadv/vadv_numba_np.py
+++ b/npbench/benchmarks/weather_stencils/vadv/vadv_numba_np.py
@@ -13,9 +13,9 @@ def vadv(utens_stage, u_stage, wcon, u_pos, utens, dtr_stage):
     # ccol = np.ndarray((I, J, K), dtype=utens_stage.dtype)
     # dcol = np.ndarray((I, J, K), dtype=utens_stage.dtype)
     # data_col = np.ndarray((I, J), dtype=utens_stage.dtype)
-    ccol = np.empty((I, J, K), dtype=utens_stage.dtype)
-    dcol = np.empty((I, J, K), dtype=utens_stage.dtype)
-    data_col = np.empty((I, J), dtype=utens_stage.dtype)
+    ccol = np.zeros((I, J, K), dtype=utens_stage.dtype)
+    dcol = np.zeros((I, J, K), dtype=utens_stage.dtype)
+    data_col = np.zeros((I, J), dtype=utens_stage.dtype)
 
     for k in range(1):
         gcv = 0.25 * (wcon[1:, :, k + 1] + wcon[:-1, :, k + 1])

--- a/npbench/benchmarks/weather_stencils/vadv/vadv_pythran.py
+++ b/npbench/benchmarks/weather_stencils/vadv/vadv_pythran.py
@@ -13,9 +13,9 @@ def vadv(utens_stage, u_stage, wcon, u_pos, utens, dtr_stage):
     # ccol = np.ndarray((I, J, K), dtype=utens_stage.dtype)
     # dcol = np.ndarray((I, J, K), dtype=utens_stage.dtype)
     # data_col = np.ndarray((I, J), dtype=utens_stage.dtype)
-    ccol = np.empty((I, J, K), dtype=utens_stage.dtype)
-    dcol = np.empty((I, J, K), dtype=utens_stage.dtype)
-    data_col = np.empty((I, J), dtype=utens_stage.dtype)
+    ccol = np.zeros((I, J, K), dtype=utens_stage.dtype)
+    dcol = np.zeros((I, J, K), dtype=utens_stage.dtype)
+    data_col = np.zeros((I, J), dtype=utens_stage.dtype)
 
     for k in range(1):
         gcv = 0.25 * (wcon[1:, :, k + 1] + wcon[:-1, :, k + 1])

--- a/npbench/infrastructure/__init__.py
+++ b/npbench/infrastructure/__init__.py
@@ -7,6 +7,7 @@ from .utilities import *
 
 from .cupy_framework import *
 from .dace_framework import *
+from .dace_canonicalize_framework import *
 from .legate_framework import *
 from .numba_framework import *
 from .pythran_framework import *

--- a/npbench/infrastructure/dace_canonicalize_framework.py
+++ b/npbench/infrastructure/dace_canonicalize_framework.py
@@ -1,0 +1,87 @@
+# Copyright 2021 ETH Zurich and the NPBench authors. All rights reserved.
+import importlib
+import traceback
+
+import numpy as np
+
+from npbench.infrastructure import Benchmark
+from npbench.infrastructure.dace_framework import DaceFramework
+from typing import Callable, Sequence, Tuple
+
+
+class DaceCanonicalizeFramework(DaceFramework):
+    """Runs DaCe's ``canonicalize`` pipeline instead of ``auto_optimize``.
+
+    Reuses the ``*_dace.py`` benchmark implementations (``postfix`` ``dace``) and every
+    calling convention of :class:`DaceFramework`; only the SDFG-optimization step differs.
+    The CPU and GPU variants share this class and differ only by the ``arch`` field in
+    their framework JSON, exactly as ``dace_cpu`` / ``dace_gpu`` share :class:`DaceFramework`.
+
+    Contrast with ``dace_cpu`` / ``dace_gpu`` (WCR-config OFF): the canonicalize pipeline
+    leaves ``sdfg.openmp_array_reductions = True`` (WCR-config ON), so a whole-buffer WCR
+    accumulator of a parallel map lowers to an OpenMP ``reduction(op:A[0:n])`` array-section
+    clause instead of per-element atomics.
+    """
+
+    def copy_func(self) -> Callable:
+        """Copy inputs to the device: cupy for the GPU variant, ``np.copy`` otherwise."""
+        if self.info["arch"] == "gpu":
+            import cupy
+
+            def cp_copy_func(arr):
+                darr = cupy.asarray(arr)
+                cupy.cuda.stream.get_current_stream().synchronize()
+                return darr
+
+            return cp_copy_func
+        return np.copy
+
+    def implementations(self, bench: Benchmark) -> Sequence[Tuple[Callable, str]]:
+        """Build the SDFG for ``bench``, run the canonicalize pipeline + target
+        finalization, turn the WCR-config ON, then compile."""
+        import dace  # noqa: F401
+        from dace.transformation.passes.canonicalize import canonicalize
+        from dace.transformation.passes.canonicalize.finalize import finalize_for_target
+
+        module_pypath = "npbench.benchmarks.{r}.{m}".format(r=bench.info["relative_path"].replace('/', '.'),
+                                                            m=bench.info["module_name"])
+        postfix = self.info["postfix"] if "postfix" in self.info.keys() else self.fname
+        module_str = "{m}_{p}".format(m=module_pypath, p=postfix)
+        func_str = bench.info["func_name"]
+
+        try:
+            module = importlib.import_module(module_str)
+            ct_impl = vars(module)[func_str]
+        except Exception as e:
+            print("Failed to load the DaCe implementation.")
+            raise e
+
+        target = "gpu" if self.info["arch"] == "gpu" else "cpu"
+
+        sdfg = ct_impl.to_sdfg(simplify=True)
+        sdfg._name = "canonicalize"
+
+        canonicalize(sdfg,
+                     validate=True,
+                     target=target,
+                     peel_limit=4,
+                     break_anti_dependence=True,
+                     interchange_carry_with_map=True,
+                     scatter_to_guarded_maps=True)
+        finalize_for_target(sdfg, target)
+
+        # WCR-config ON. ``canonicalize`` already sets this on every nested SDFG at the end of
+        # the pipeline; set it again explicitly right before compile for clarity.
+        for nested in sdfg.all_sdfgs_recursive():
+            nested.openmp_array_reductions = True
+
+        implementations = []
+        try:
+            dc_exec = sdfg.compile()
+            implementations.append((dc_exec, sdfg._name))
+        except Exception as e:
+            print("Failed to compile DaCe {a} canonicalize implementation.".format(a=self.info["arch"]))
+            print(e)
+            traceback.print_exc()
+
+        return implementations

--- a/npbench/infrastructure/dace_framework.py
+++ b/npbench/infrastructure/dace_framework.py
@@ -274,6 +274,11 @@ class DaceFramework(Framework):
                 else:
                     gpu_time1 = [0]
                 fe_time += gpu_time1[0]
+            # WCR-config OFF: dace_cpu / dace_gpu keep the default per-element atomic WCR
+            # lowering (contrast dace_canonicalize_cpu / dace_canonicalize_gpu, which turn ON
+            # OpenMP array-section reductions). Set it explicitly for clarity before compile.
+            for nested in sdfg.all_sdfgs_recursive():
+                nested.openmp_array_reductions = False
             try:
                 dc_exec, compile_time = util.benchmark("__npb_result = sdfg.compile()",
                                                        out_text="DaCe compilation time",


### PR DESCRIPTION
Three changes.

## 1. `np.empty` / `np.empty_like` -> `np.zeros` / `np.zeros_like`

256 sites across 132 files, all backends (numpy, dace, numba, cupy, dpnp, pythran, legate, jax).

An uninitialized `empty` buffer that a kernel writes only **partially** leaves stale/garbage memory in the result. Those kernels are therefore read-nondeterministic: the same input can yield different outputs on different runs, and the comparison against the reference flakes. Zero-initializing makes every run reproducible. For buffers that are fully overwritten before use the change is equivalent, so all sites are converted uniformly. Commented-out code is left untouched.

## 2. Well-conditioned Gram-Schmidt input

`gramschmidt`'s `initialize` now builds a deterministically full-column-rank, well-conditioned matrix via a diagonal-dominance term, replacing the reject-sampling `while np.linalg.matrix_rank(A) < N` loop:

```python
A = rng.random((M, N), dtype=datatype)
A[:N, :N] += N * np.eye(N, dtype=datatype)
```

A plain random matrix is only full-rank *in expectation* and can still be poorly conditioned, which makes the QR numerically unstable and sensitive to harmless FMA-contraction reassociation. The added diagonal gives `cond(A) ~= 1.5` deterministically. All framework implementations validate against the same-input NumPy reference, so the change is self-consistent.

## 3. New frameworks: `dace_canonicalize_cpu` / `dace_canonicalize_gpu`

Two frameworks that run DaCe's `canonicalize` pipeline instead of `auto_optimize`, to contrast the WCR (write-conflict-resolution) reduction lowering:

- The new frameworks build the SDFG, run `canonicalize(target=cpu|gpu, peel_limit=4, break_anti_dependence=True, interchange_carry_with_map=True, scatter_to_guarded_maps=True)` + `finalize_for_target`, leaving `sdfg.openmp_array_reductions = True` (WCR-config ON) so a whole-buffer WCR accumulator of a parallel map lowers to an OpenMP `reduction(op:A[0:n])` array-section clause instead of per-element atomics.
- The existing `dace_cpu` / `dace_gpu` now set `openmp_array_reductions = False` explicitly before compile (WCR-config OFF, the default per-element atomic path).

Registered exactly like `dace_cpu`/`dace_gpu`: `framework_info/dace_canonicalize_{cpu,gpu}.json` + a `DaceCanonicalizeFramework` class (a `DaceFramework` subclass shared by both arches, selected by the JSON `arch` field). Reuses the existing `*_dace.py` implementations and every `DaceFramework` calling convention.

Verified: the CPU variant builds, runs and validates against NumPy on `atax` (a reduction kernel). The GPU variant is defined/registered analogously and builds + canonicalizes; fully running it needs the GPU device-schedule assignment that DaCe's `canonicalize(target='gpu')` path does not yet emit, so it is definition-only for now.
